### PR TITLE
ErrorEvaluator

### DIFF
--- a/src/main/scala/com/stripe/brushfire/Evaluators.scala
+++ b/src/main/scala/com/stripe/brushfire/Evaluators.scala
@@ -45,3 +45,18 @@ case class EmptySplit[V, P] extends Split[V, P] {
   val predicates = Nil
 }
 
+case class ErrorEvaluator[V, T, E](error: Error[T, E])(fn: E => Double)
+    extends Evaluator[V, T] {
+  def evaluate(split: Split[V, T]) = {
+    val totalErrorOption =
+      error.semigroup.sumOption(
+        split
+          .predicates
+          .map { case (_, target) => error.create(target, Some(target)) })
+
+    totalErrorOption match {
+      case Some(totalError) => (split, fn(totalError) * -1)
+      case None => (EmptySplit[V, T], Double.NegativeInfinity)
+    }
+  }
+}


### PR DESCRIPTION
This is a much simpler but less satisfying version of https://github.com/stripe/brushfire/pull/18, which just lets you wrap an Evaluator around an Error, without actually eliminating the Evaluator trait.

cc @snoble 
