### PR TITLE
Voter trait

### DIFF
--- a/src/main/scala/com/stripe/brushfire/Brushfire.scala
+++ b/src/main/scala/com/stripe/brushfire/Brushfire.scala
@@ -74,8 +74,16 @@ trait Sampler[-K] {
   def includeFeature(key: K, treeIndex: Int, leafIndex: Int): Boolean
 }
 
+/** Combines multiple targets into a single prediction **/
+trait Voter[T, P] {
+  def predict[K, V](trees: Iterable[Tree[K, V, T]], row: Map[K, V]): P =
+    combine(trees.flatMap { _.targetFor(row) })
+
+  def combine(targets: Iterable[T]): P
+}
+
 /** Computes some kind of error by comparing the trees' predictions to the validation set */
-trait Error[T, E] {
+trait Error[T, P, E] {
   /** semigroup to sum up error values */
   def semigroup: Semigroup[E]
 
@@ -85,5 +93,5 @@ trait Error[T, E] {
    * @param actual the actual target distribution from the validation set
    * @param predicted the set of predicted distributions from the trees
    */
-  def create(actual: T, predicted: Iterable[T]): E
+  def create(actual: T, predicted: P): E
 }

--- a/src/main/scala/com/stripe/brushfire/Defaults.scala
+++ b/src/main/scala/com/stripe/brushfire/Defaults.scala
@@ -26,6 +26,8 @@ trait Defaults extends LowPriorityDefaults {
     continuous: Splitter[C, Map[L, Long]]): Splitter[Dispatched[A, B, C, D], Map[L, Long]] =
     new DispatchedSplitter(ordinal, nominal, continuous, SpaceSaverSplitter[D, L]())
 
+  implicit def softVoter[L]: Voter[Map[L, Long], Map[L, Double]] = SoftVoter[L]
+
   def downRez(v: Double, base: Int, precision: Int): Double = {
     if (v == 0.0)
       0.0

--- a/src/main/scala/com/stripe/brushfire/Defaults.scala
+++ b/src/main/scala/com/stripe/brushfire/Defaults.scala
@@ -26,7 +26,7 @@ trait Defaults extends LowPriorityDefaults {
     continuous: Splitter[C, Map[L, Long]]): Splitter[Dispatched[A, B, C, D], Map[L, Long]] =
     new DispatchedSplitter(ordinal, nominal, continuous, SpaceSaverSplitter[D, L]())
 
-  implicit def softVoter[L]: Voter[Map[L, Long], Map[L, Double]] = SoftVoter[L]
+  implicit def softVoter[L, M: Numeric]: Voter[Map[L, M], Map[L, Double]] = SoftVoter[L, M]
 
   def downRez(v: Double, base: Int, precision: Int): Double = {
     if (v == 0.0)

--- a/src/main/scala/com/stripe/brushfire/Errors.scala
+++ b/src/main/scala/com/stripe/brushfire/Errors.scala
@@ -139,7 +139,7 @@ object BrierScore {
  */
 
 case class BrierDecompositionError[A](bins: Int = 10) extends FrequencyError[A, BrierScore[A, Double]] {
-  val monoid = BrierScore.monoid[A, Double]
+  lazy val monoid = BrierScore.monoid[A, Double]
 
   def bin(x: Double): Double = (x * bins).toInt / bins.toDouble
 

--- a/src/main/scala/com/stripe/brushfire/Errors.scala
+++ b/src/main/scala/com/stripe/brushfire/Errors.scala
@@ -2,31 +2,37 @@ package com.stripe.brushfire
 
 import com.twitter.algebird._
 
-case class BinnedError[B, T: Monoid](binner: Iterable[T] => B) extends Error[T, Map[B, T]] {
-  val semigroup = implicitly[Semigroup[Map[B, T]]]
+/**
+ * FrequencyError sets up the most common case when dealing
+ * with discrete distributions:
+ * - normalize each prediction before combining them
+ * - normalize to probablities after combining
+ * - compute and sum errors separately for each component of the actual distribution
+ * - provide a zero for when predictions or actuals are missing
+ */
+trait FrequencyError[L, E] extends Error[Map[L, Long], E] {
 
-  def create(actual: T, predicted: Iterable[T]) = Map(binner(predicted) -> actual)
-}
+  val semigroup = monoid
 
-object Errors {
-  def averageProbability(predicted: Iterable[Map[Boolean, Long]]): Double = {
-    if (predicted.size == 0)
-      0.0
+  def monoid: Monoid[E]
+
+  def normalizedFrequencies(m: Map[L, Long]): Map[L, Double] = {
+    val nonNeg = m.mapValues { n => math.max(n, 0L) }
+    val total = math.max(nonNeg.values.sum, 1L)
+    nonNeg.mapValues { _.toDouble / total }
+  }
+
+  def create(actual: Map[L, Long], predicted: Iterable[Map[L, Long]]) = {
+    if (predicted.isEmpty)
+      monoid.zero
     else {
-      val scores = predicted.map { m =>
-        val trues = math.max(m.getOrElse(true, 0L).toDouble, 0.0)
-        val falses = math.max(m.getOrElse(false, 0L).toDouble, 0.0)
-        if (trues == 0.0)
-          0.0
-        else
-          trues / (falses + trues)
-      }
-      scores.sum / scores.size
+      val normalized = predicted.map(normalizedFrequencies)
+      val probabilities = Monoid.sum(normalized).mapValues { _ / predicted.size }
+      monoid.sum(actual.map { case (label, count) => error(label, count, probabilities) })
     }
   }
 
-  def averagePercentage(predicted: Iterable[Map[Boolean, Long]]): Double =
-    Math.floor(averageProbability(predicted) * 100) / 100.0
+  def error(label: L, count: Long, probabilities: Map[L, Double]): E
 }
 
 /**
@@ -36,7 +42,7 @@ object Errors {
  *
  * @tparam A the classes to be predicted into.
  * @tparam B the probability distribution bins.
- * @param predicted every time an example is falls into a (predicted class, predicted probability bin), that probability is added here.
+ * @param predicted every time an example falls into a (predicted class, predicted probability bin), that probability is added here.
  * @param actual counts the number of examples per (predicted class, predicted probability bin) that actually fall into the predicted class.
  * @param counts the total number of examples in each (predicted class, predicted probability bin).
  * @param totalCount the total number of examples.
@@ -111,50 +117,37 @@ case class BrierScore[A, B](predicted: Map[(A, B), Double], actual: Map[(A, B), 
   def score: Double = reliability - resolution + uncertainty
 }
 
-/**
- * BrierScoreSemigroup is a semigroup for adding BrierScores.
- */
-case class BrierScoreSemigroup[A, B] extends Semigroup[BrierScore[A, B]] {
+object BrierScore {
+  implicit def monoid[A, B]: Monoid[BrierScore[A, B]] = new Monoid[BrierScore[A, B]] {
+    val zero = BrierScore[A, B](Map[(A, B), Double](), Map[(A, B), Long](), Map[(A, B), Long](), 0L)
 
-  def plus(l: BrierScore[A, B], r: BrierScore[A, B]): BrierScore[A, B] = {
-    BrierScore[A, B](Monoid.plus(l.predicted, r.predicted),
-      Monoid.plus(l.actual, r.actual),
-      Monoid.plus(l.counts, r.counts),
-      l.totalCount + r.totalCount)
+    def plus(l: BrierScore[A, B], r: BrierScore[A, B]): BrierScore[A, B] = {
+      BrierScore[A, B](Monoid.plus(l.predicted, r.predicted),
+        Monoid.plus(l.actual, r.actual),
+        Monoid.plus(l.counts, r.counts),
+        l.totalCount + r.totalCount)
+    }
   }
-
 }
 
 /**
  * BrierDecompositionError computes Brier scores and their decompositions.
  *
- * The bins used in the Brier score calculation are deciles (represented by a Double of the lower endpoint).
- *
+ * The bins used in the Brier score calculation are quantiles (represented by a Double of the lower endpoint).
+ * @param bins the number of bins to use (defaults to 10, ie deciles)
  * @tparam A the classes to be predicted into.
  */
-case class BrierDecompositionError[A] extends Error[Map[A, Long], BrierScore[A, Double]] {
-  val semigroup = BrierScoreSemigroup[A, Double]()
 
-  def decileBinner(x: Double): Double = (x * 10).toInt / 10.0
+case class BrierDecompositionError[A](bins: Int = 10) extends FrequencyError[A, BrierScore[A, Double]] {
+  val monoid = BrierScore.monoid[A, Double]
 
-  def normalizedFrequencies(m: Map[A, Long]): Map[A, Double] = {
-    val nonNeg = m.mapValues { n => math.max(n, 0L) }
-    val total = math.max(nonNeg.values.sum, 1L)
-    nonNeg.mapValues { _.toDouble / total }
-  }
+  def bin(x: Double): Double = (x * bins).toInt / bins.toDouble
 
-  def create(actual: Map[A, Long], predicted: Iterable[Map[A, Long]]): BrierScore[A, Double] = {
-    predicted match {
-      case Nil => BrierScore[A, Double](Map[(A, Double), Double](), Map[(A, Double), Long](), Map[(A, Double), Long](), 0L)
-      case _ =>
-        val probs = predicted.map(normalizedFrequencies)
-        val averagedScores = Monoid.sum(probs).mapValues { _ / predicted.size }
+  def error(label: A, count: Long, probabilities: Map[A, Double]) = {
+    val binnedPredictions = probabilities.map { case (a, score) => ((a, bin(score)), score * count) }
+    val binnedActuals = binnedPredictions.map { case (ab, _) => (ab, if (label == ab._1) count else 0L) }
+    val binCounts = binnedPredictions.map { case (ab, _) => (ab, count) }
 
-        val binnedPredictions = (averagedScores).map { case (a, score) => ((a, decileBinner(score)), score) }
-        val binnedActuals = binnedPredictions.map { case (ab, _) => (ab, actual.getOrElse(ab._1, 0L)) }
-        val binCounts = binnedPredictions.map { case (ab, _) => (ab, 1L) }
-
-        BrierScore[A, Double](binnedPredictions, binnedActuals, binCounts, 1L)
-    }
+    BrierScore(binnedPredictions, binnedActuals, binCounts, count)
   }
 }

--- a/src/main/scala/com/stripe/brushfire/Errors.scala
+++ b/src/main/scala/com/stripe/brushfire/Errors.scala
@@ -35,119 +35,24 @@ trait FrequencyError[L, E] extends Error[Map[L, Long], E] {
   def error(label: L, count: Long, probabilities: Map[L, Double]): E
 }
 
-/**
- * BrierScore is a container for tracking the Brier score decomposition of a set of errors.
- *
- * See http://www.eumetcal.org/intralibrary/open_virtual_file_path/i2055n15861t/english/msg/ver_prob_forec/uos2/uos2_ko2.htm for more information.
- *
- * @tparam A the classes to be predicted into.
- * @tparam B the probability distribution bins.
- * @param predicted every time an example falls into a (predicted class, predicted probability bin), that probability is added here.
- * @param actual counts the number of examples per (predicted class, predicted probability bin) that actually fall into the predicted class.
- * @param counts the total number of examples in each (predicted class, predicted probability bin).
- * @param totalCount the total number of examples.
- */
-case class BrierScore[A, B](predicted: Map[(A, B), Double], actual: Map[(A, B), Long], counts: Map[(A, B), Long], totalCount: Long) {
+case class BrierScoreError[L] extends FrequencyError[L, AveragedValue] {
+  lazy val monoid = AveragedValue.group
 
-  /**
-   * actualClassRates contains the percentage of observations that fall into each class.
-   */
-  def actualClassRates: Map[A, Double] = {
-    val actualClassCounts = actual.groupBy { case (ab, ct) => ab._1 }.mapValues { _.map(_._2).sum }
-
-    actualClassCounts.mapValues { _ / math.max(totalCount.toDouble, 1.0) }
-  }
-
-  /**
-   * Reliability measures how close forecast probabilities are to the true probabilities, and is defined as
-   *
-   *   reliability = 1 / (total # of examples) * sum_{class a} sum_{bin b} [
-   *                   (# of examples that are predicted to fall into class a with probability in bin b) *
-   *                   (predicted probability - % of these examples that actually fall into class a)^2 ]
-   *               = 1 / (total # of examples) * sum_{class a} sum_{bin b} [
-   *                   (weighted count of examples that fall into class a with probability in bin b, where weights are the probability -
-   *                   # of these examples that actually fall into bin b)^2 /
-   *                   (# of examples that are predicted to fall into class a with probability in bin b)]
-   */
-  def reliability: Double = {
-    if (totalCount == 0) {
-      0.0
-    } else {
-      val inverseCounts = counts.filter { _._2 > 0.0 }.mapValues { 1.0 / _ }
-      val predictedProbs = Ring.times(predicted, inverseCounts)
-      val actualRates = Ring.times(actual.mapValues { _.toDouble }, inverseCounts)
-      val sqDiffs = Group.minus(predictedProbs, actualRates).mapValues { math.pow(_, 2) }
-      val weightedSum = Ring.times(sqDiffs, counts.mapValues { _.toDouble }).values.sum
-
-      weightedSum / totalCount
-    }
-  }
-
-  /**
-   * Resolution measures how much the conditional probabilities for each <class, bin> differ from the overall class probabilities,
-   * and is defined as
-   *
-   *   resolution = 1 / (total # of examples) * sum_{class a} sum_{bin b} [
-   *                  (# of examples that are predicted to fall into class a with probability in bin b) *
-   *                  (% of these examples that actually fall into class a - % of all examples that fall into class a)^2 ]
-   */
-  def resolution: Double = {
-    if (totalCount == 0) {
-      0.0
-    } else {
-      val inverseCounts = counts.filter { _._2 > 0.0 }.mapValues { 1.0 / _ }
-      val actualRates = Ring.times(actual.mapValues { _.toDouble }, inverseCounts)
-      val sqDiffs = actualRates.map { case (ab, rate) => (ab, math.pow(rate - actualClassRates.getOrElse(ab._1, 0.0), 2).toDouble) }
-      val weightedSum = Ring.times(sqDiffs, counts.mapValues { _.toDouble }).values.sum
-
-      weightedSum / totalCount
-    }
-  }
-
-  /**
-   * Uncertainty measures the inherent uncertainty of the event, and is defined as
-   *
-   *   uncertainty = sum_{class a} (% of examples that fall into class a) * (1 - % of examples that fall into class a)
-   */
-  def uncertainty: Double = actualClassRates.mapValues { r => r * (1 - r) }.values.sum
-
-  /**
-   * Score is the total Brier score.
-   */
-  def score: Double = reliability - resolution + uncertainty
-}
-
-object BrierScore {
-  implicit def monoid[A, B]: Monoid[BrierScore[A, B]] = new Monoid[BrierScore[A, B]] {
-    val zero = BrierScore[A, B](Map[(A, B), Double](), Map[(A, B), Long](), Map[(A, B), Long](), 0L)
-
-    def plus(l: BrierScore[A, B], r: BrierScore[A, B]): BrierScore[A, B] = {
-      BrierScore[A, B](Monoid.plus(l.predicted, r.predicted),
-        Monoid.plus(l.actual, r.actual),
-        Monoid.plus(l.counts, r.counts),
-        l.totalCount + r.totalCount)
-    }
+  def error(label: L, count: Long, probabilities: Map[L, Double]): AveragedValue = {
+    val differences = Group.minus(Map(label -> 1.0), probabilities)
+    val sumSquareDifferences = differences.values.map { math.pow(_, 2) }.sum
+    AveragedValue(count, sumSquareDifferences / math.max(differences.size, 1L))
   }
 }
 
-/**
- * BrierDecompositionError computes Brier scores and their decompositions.
- *
- * The bins used in the Brier score calculation are quantiles (represented by a Double of the lower endpoint).
- * @param bins the number of bins to use (defaults to 10, ie deciles)
- * @tparam A the classes to be predicted into.
- */
+case class BinnedBinaryError
+    extends FrequencyError[Boolean, Map[Int, (Long, Long)]] {
+  lazy val monoid = implicitly[Monoid[Map[Int, (Long, Long)]]]
 
-case class BrierDecompositionError[A](bins: Int = 10) extends FrequencyError[A, BrierScore[A, Double]] {
-  lazy val monoid = BrierScore.monoid[A, Double]
+  private def percentage(p: Double) = (p * 100).toInt
 
-  def bin(x: Double): Double = (x * bins).toInt / bins.toDouble
-
-  def error(label: A, count: Long, probabilities: Map[A, Double]) = {
-    val binnedPredictions = probabilities.map { case (a, score) => ((a, bin(score)), score * count) }
-    val binnedActuals = binnedPredictions.map { case (ab, _) => (ab, if (label == ab._1) count else 0L) }
-    val binCounts = binnedPredictions.map { case (ab, _) => (ab, count) }
-
-    BrierScore(binnedPredictions, binnedActuals, binCounts, count)
+  def error(label: Boolean, count: Long, probabilities: Map[Boolean, Double]) = {
+    val tuple = if (label) (count, 0L) else (0L, count)
+    Map(percentage(probabilities.getOrElse(true, 0.0)) -> tuple)
   }
 }

--- a/src/main/scala/com/stripe/brushfire/Evaluators.scala
+++ b/src/main/scala/com/stripe/brushfire/Evaluators.scala
@@ -45,14 +45,14 @@ case class EmptySplit[V, P] extends Split[V, P] {
   val predicates = Nil
 }
 
-case class ErrorEvaluator[V, T, E](error: Error[T, E])(fn: E => Double)
+case class ErrorEvaluator[V, T, P, E](error: Error[T, P, E], voter: Voter[T, P])(fn: E => Double)
     extends Evaluator[V, T] {
   def evaluate(split: Split[V, T]) = {
     val totalErrorOption =
       error.semigroup.sumOption(
         split
           .predicates
-          .map { case (_, target) => error.create(target, Some(target)) })
+          .map { case (_, target) => error.create(target, voter.combine(Some(target))) })
 
     totalErrorOption match {
       case Some(totalError) => (split, fn(totalError) * -1)

--- a/src/main/scala/com/stripe/brushfire/Voters.scala
+++ b/src/main/scala/com/stripe/brushfire/Voters.scala
@@ -2,32 +2,32 @@ package com.stripe.brushfire
 
 import com.twitter.algebird._
 
-trait FrequencyVoter[L] extends Voter[Map[L, Long], Map[L, Double]] {
-  def normalize(m: Map[L, Long]): Map[L, Double] = {
-    val nonNeg = m.mapValues { n => math.max(n, 0L) }
-    val total = math.max(nonNeg.values.sum, 1L)
-    nonNeg.mapValues { _.toDouble / total }
+trait FrequencyVoter[L, M] extends Voter[Map[L, M], Map[L, Double]] {
+  def normalize[N](m: Map[L, N])(implicit num: Numeric[N]): Map[L, Double] = {
+    val nonNeg = m.mapValues { n => math.max(num.toDouble(n), 0.0) }
+    val total = math.max(nonNeg.values.sum, 1.0)
+    nonNeg.mapValues { _ / total }
   }
 }
 
-case class SoftVoter[L] extends FrequencyVoter[L] {
-  def combine(targets: Iterable[Map[L, Long]]) =
+case class SoftVoter[L, M: Numeric] extends FrequencyVoter[L, M] {
+  def combine(targets: Iterable[Map[L, M]]) =
     if (targets.isEmpty)
       Map.empty[L, Double]
     else
-      Monoid.sum(targets.map(normalize)).mapValues { _ / targets.size }
+      Monoid.sum(targets.map { m => normalize(m) }).mapValues { _ / targets.size }
 }
 
-case class ModeVoter[L] extends FrequencyVoter[L] {
-  def mode(m: Map[L, Long]) = m.maxBy { _._2 }._1
+case class ModeVoter[L, M: Ordering] extends FrequencyVoter[L, M] {
+  def mode(m: Map[L, M]): L = m.maxBy { _._2 }._1
 
-  def combine(targets: Iterable[Map[L, Long]]) =
-    normalize(Monoid.sum(targets.map { m => Map(mode(m) -> 1L) }))
+  def combine(targets: Iterable[Map[L, M]]) =
+    normalize(Monoid.sum(targets.map { m => Map(mode(m) -> 1.0) }))
 }
 
-case class ThresholdVoter(threshold: Double, freqVoter: FrequencyVoter[Boolean])
-    extends Voter[Map[Boolean, Long], Boolean] {
+case class ThresholdVoter[M](threshold: Double, freqVoter: FrequencyVoter[Boolean, M])
+    extends Voter[Map[Boolean, M], Boolean] {
 
-  def combine(targets: Iterable[Map[Boolean, Long]]) =
+  def combine(targets: Iterable[Map[Boolean, M]]) =
     freqVoter.combine(targets).getOrElse(true, 0.0) > threshold
 }

--- a/src/main/scala/com/stripe/brushfire/Voters.scala
+++ b/src/main/scala/com/stripe/brushfire/Voters.scala
@@ -1,0 +1,33 @@
+package com.stripe.brushfire
+
+import com.twitter.algebird._
+
+trait FrequencyVoter[L] extends Voter[Map[L, Long], Map[L, Double]] {
+  def normalize(m: Map[L, Long]): Map[L, Double] = {
+    val nonNeg = m.mapValues { n => math.max(n, 0L) }
+    val total = math.max(nonNeg.values.sum, 1L)
+    nonNeg.mapValues { _.toDouble / total }
+  }
+}
+
+case class SoftVoter[L] extends FrequencyVoter[L] {
+  def combine(targets: Iterable[Map[L, Long]]) =
+    if (targets.isEmpty)
+      Map.empty[L, Double]
+    else
+      Monoid.sum(targets.map(normalize)).mapValues { _ / targets.size }
+}
+
+case class ModeVoter[L] extends FrequencyVoter[L] {
+  def mode(m: Map[L, Long]) = m.maxBy { _._2 }._1
+
+  def combine(targets: Iterable[Map[L, Long]]) =
+    normalize(Monoid.sum(targets.map { m => Map(mode(m) -> 1L) }))
+}
+
+case class ThresholdVoter(threshold: Double, freqVoter: FrequencyVoter[Boolean])
+    extends Voter[Map[Boolean, Long], Boolean] {
+
+  def combine(targets: Iterable[Map[Boolean, Long]]) =
+    freqVoter.combine(targets).getOrElse(true, 0.0) > threshold
+}

--- a/src/main/scala/com/stripe/brushfire/scalding/Example.scala
+++ b/src/main/scala/com/stripe/brushfire/scalding/Example.scala
@@ -23,7 +23,7 @@ class IrisJob(args: Args) extends TrainerJob(args) {
     Trainer(trainingData, KFoldSampler(4))
       .expandTimes(args("output"), 3)
       .expandInMemory(args("output") + "/mem", 10)
-      .validate(BrierDecompositionError[String]) { results =>
+      .validate(BrierDecompositionError[String]()) { results =>
         results.map { v => (v.reliability, v.resolution, v.uncertainty, v.score) }.writeExecution(TypedTsv(args("output") + "/bs"))
       }
 }

--- a/src/main/scala/com/stripe/brushfire/scalding/Example.scala
+++ b/src/main/scala/com/stripe/brushfire/scalding/Example.scala
@@ -23,7 +23,7 @@ class IrisJob(args: Args) extends TrainerJob(args) {
     Trainer(trainingData, KFoldSampler(4))
       .expandTimes(args("output"), 3)
       .expandInMemory(args("output") + "/mem", 10)
-      .validate(BrierDecompositionError[String]()) { results =>
-        results.map { v => (v.reliability, v.resolution, v.uncertainty, v.score) }.writeExecution(TypedTsv(args("output") + "/bs"))
+      .validate(BrierScoreError[String]) { results =>
+        results.map { _.toString }.writeExecution(TypedTsv(args("output") + "/bs"))
       }
 }

--- a/src/main/scala/com/stripe/brushfire/scalding/Example.scala
+++ b/src/main/scala/com/stripe/brushfire/scalding/Example.scala
@@ -26,4 +26,7 @@ class IrisJob(args: Args) extends TrainerJob(args) {
       .validate(BrierScoreError[String]) { results =>
         results.map { _.toString }.writeExecution(TypedTsv(args("output") + "/bs"))
       }
+      .featureImportance(BrierScoreError[String]) { results =>
+        results.map { _.toString }.writeExecution(TypedTsv(args("output") + "/fi"))
+      }
 }

--- a/src/main/scala/com/stripe/brushfire/scalding/Example.scala
+++ b/src/main/scala/com/stripe/brushfire/scalding/Example.scala
@@ -19,14 +19,15 @@ class IrisJob(args: Args) extends TrainerJob(args) {
       }
 
   implicit val stopper = FrequencyStopper[String](10, 3)
+  val error = BrierScoreError[String, Long]
   val trainer =
     Trainer(trainingData, KFoldSampler(4))
       .expandTimes(args("output"), 3)
       .expandInMemory(args("output") + "/mem", 10)
-      .validate(BrierScoreError[String]) { results =>
+      .validate(error) { results =>
         results.map { _.toString }.writeExecution(TypedTsv(args("output") + "/bs"))
       }
-      .featureImportance(BrierScoreError[String]) { results =>
+      .featureImportance(error) { results =>
         results.map { _.toString }.writeExecution(TypedTsv(args("output") + "/fi"))
       }
 }


### PR DESCRIPTION
Adds a new trait, `Voter`, which is responsible of normalizing and combining predictions across multiple trees in an ensemble. This also introduces a new type parameter, `P`, which is used by both `Voter` and `Error`, for the combined prediction.

This also temporarily shelves `BrierDecompositionError` and brings back the earlier `BrierScoreError`, for now, until I get a chance to debug the former.