### PR TITLE
add optional groupBy args to validate and featureImportance

### DIFF
--- a/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Example.scala
+++ b/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Example.scala
@@ -24,7 +24,7 @@ class IrisJob(args: Args) extends TrainerJob(args) {
     Trainer(trainingData, KFoldSampler(4))
       .expandTimes(args("output"), 3)
       .expandInMemory(args("output") + "/mem", 10)
-      .validate(error) { results =>
+      .validate(error, _.target.keys.head) { results =>
         results.map { _.toString }.writeExecution(TypedTsv(args("output") + "/bs"))
       }
       .featureImportance(error) { results =>


### PR DESCRIPTION
These changes recognize that often you want to output the error or featureImportance for each of a bunch of segmentations of the validation set (for example, the error per month, for time series data). 