### PR TITLE
Fix some scala cross-building issues

### DIFF
--- a/brushfire-core/pom.xml
+++ b/brushfire-core/pom.xml
@@ -6,7 +6,7 @@
   <packaging>jar</packaging>
 
   <parent>
-    <artifactId>brushfire-parent</artifactId>
+    <artifactId>brushfire-parent_${scala.binary.version}</artifactId>
     <groupId>com.stripe</groupId>
     <version>0.5.0-SNAPSHOT</version>
     <relativePath>../brushfire-parent</relativePath>

--- a/brushfire-finatra/pom.xml
+++ b/brushfire-finatra/pom.xml
@@ -6,7 +6,7 @@
   <packaging>jar</packaging>
 
   <parent>
-    <artifactId>brushfire-parent</artifactId>
+    <artifactId>brushfire-parent_${scala.binary.version}</artifactId>
     <groupId>com.stripe</groupId>
     <version>0.5.0-SNAPSHOT</version>
     <relativePath>../brushfire-parent</relativePath>

--- a/brushfire-parent/pom.xml
+++ b/brushfire-parent/pom.xml
@@ -5,7 +5,7 @@
   <modelVersion>4.0.0</modelVersion>
 
   <groupId>com.stripe</groupId>
-  <artifactId>brushfire-parent</artifactId>
+  <artifactId>brushfire-parent_${scala.binary.version}</artifactId>
   <packaging>pom</packaging>
   <version>0.5.0-SNAPSHOT</version>
 
@@ -187,6 +187,24 @@
             <phase>process-sources</phase>
             <goals>
               <goal>format</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.sap.prd.mobile.ios.maven.plugins</groupId>
+        <artifactId>resolve-pom-maven-plugin</artifactId>
+        <version>1.0</version>
+        <configuration>
+          <resolvedPomName>target/resolved-pom.xml</resolvedPomName>
+        </configuration>
+        <executions>
+          <execution>
+            <id>resolve-pom-props</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>resolve-pom-props</goal>
             </goals>
           </execution>
         </executions>

--- a/brushfire-scalding/pom.xml
+++ b/brushfire-scalding/pom.xml
@@ -6,7 +6,7 @@
   <packaging>jar</packaging>
 
   <parent>
-    <artifactId>brushfire-parent</artifactId>
+    <artifactId>brushfire-parent_${scala.binary.version}</artifactId>
     <groupId>com.stripe</groupId>
     <version>0.5.0-SNAPSHOT</version>
     <relativePath>../brushfire-parent</relativePath>


### PR DESCRIPTION
Namely, brushfire-parent needs to be versioned along with everything else. I've
also added the resolve-pom-plugin, so that there aren't issues with floating
variables.

@avibryant @roban 