### PR TITLE
Initial Spark Support (Port of Scalding)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@ target/
 .idea/
 *.iml
 *.DS_Store
+*.swp
 tags

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ target/
 .idea/
 *.iml
 *.DS_Store
+tags

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Brushfire.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Brushfire.scala
@@ -54,8 +54,25 @@ trait Evaluator[V, T] {
 
 /** Provides stopping conditions which guide when splits will be attempted */
 trait Stopper[T] {
+
+  /**
+   * Returns `true` if we should continue to split a leaf with the given
+   * distribution.
+   */
   def shouldSplit(target: T): Boolean
+
+  /**
+   * Returns `true` if, ideally, we should avoid splitting a leaf with the
+   * given distribution in-memory.
+   */
   def shouldSplitDistributed(target: T): Boolean
+
+  /**
+   * For the given distribution, this will return the rate at which we should
+   * sample the instances if we wish to make a split in-memory. This method
+   * should return a *safe* value, such that if we sample at the given rate,
+   * all instances should fit in memory.
+   */
   def samplingRateToSplitLocally(target: T): Double
 }
 

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Tree.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Tree.scala
@@ -3,11 +3,14 @@ package com.stripe.brushfire
 import com.twitter.algebird._
 
 sealed trait Node[K, V, T]
-case class SplitNode[K, V, T](val children: Seq[(K, Predicate[V], Node[K, V, T])]) extends Node[K, V, T]
+case class SplitNode[K, V, T](children: Seq[(K, Predicate[V], Node[K, V, T])]) extends Node[K, V, T]
 case class LeafNode[K, V, T](
-  val index: Int,
+  index: Int,
   target: T) extends Node[K, V, T]
 
+/**
+ * A decision tree whose features are indexed by `K` with values of `V`.
+ */
 case class Tree[K, V, T](root: Node[K, V, T]) {
   private def findLeaf(row: Map[K, V], start: Node[K, V, T]): Option[LeafNode[K, V, T]] = {
     start match {
@@ -114,11 +117,14 @@ case class Tree[K, V, T](root: Node[K, V, T]) {
     }
   }
 
-  def leafFor(row: Map[K, V]) = findLeaf(row, root)
+  /**
+   * Returns the leaf node containing the given instance.
+   */
+  def leafFor(row: Map[K, V]): Option[LeafNode[K, V, T]] = findLeaf(row, root)
 
-  def leafIndexFor(row: Map[K, V]) = findLeaf(row, root).map { _.index }
+  def leafIndexFor(row: Map[K, V]): Option[Int] = findLeaf(row, root).map { _.index }
 
-  def targetFor(row: Map[K, V]) = findLeaf(row, root).map { _.target }
+  def targetFor(row: Map[K, V]): Option[T] = findLeaf(row, root).map { _.target }
 
   def growByLeafIndex(fn: Int => Seq[(K, Predicate[V], T)]) = {
     var newIndex = -1

--- a/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Trainer.scala
+++ b/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Trainer.scala
@@ -1,6 +1,6 @@
-package com.stripe.brushfire.scalding
+package com.stripe.brushfire
+package scalding
 
-import com.stripe.brushfire._
 import com.twitter.scalding._
 import com.twitter.algebird._
 import com.twitter.bijection._

--- a/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Trainer.scala
+++ b/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Trainer.scala
@@ -32,7 +32,10 @@ case class Trainer[K: Ordering, V, T: Monoid](
 
   def execution = Execution.zip(treeExecution, unitExecution).unit
 
-  def flatMapTrees(fn: ((TypedPipe[Instance[K, V, T]], Sampler[K], Iterable[(Int, Tree[K, V, T])])) => Execution[TypedPipe[(Int, Tree[K, V, T])]]) = {
+  /**
+   * Transform the decision [[Tree]]s in this [[Trainer]].
+   */
+  def flatMapTrees(fn: ((TypedPipe[Instance[K, V, T]], Sampler[K], Iterable[(Int, Tree[K, V, T])])) => Execution[TypedPipe[(Int, Tree[K, V, T])]]): Trainer[K, V, T] = {
     val newExecution = treeExecution
       .flatMap { trees =>
         Execution.zip(trainingDataExecution, samplerExecution, trees.toIterableExecution)
@@ -40,12 +43,20 @@ case class Trainer[K: Ordering, V, T: Monoid](
     copy(treeExecution = newExecution)
   }
 
-  def flatMapSampler(fn: ((TypedPipe[Instance[K, V, T]], Sampler[K])) => Execution[Sampler[K]]) = {
+  /**
+   * Transform the [[Sampler]] used for this `Trainer`.
+   */
+  def flatMapSampler(fn: ((TypedPipe[Instance[K, V, T]], Sampler[K])) => Execution[Sampler[K]]): Trainer[K, V, T] = {
     val newExecution = trainingDataExecution.zip(samplerExecution).flatMap(fn)
     copy(samplerExecution = newExecution)
   }
 
-  def tee[A](fn: ((TypedPipe[Instance[K, V, T]], Sampler[K], Iterable[(Int, Tree[K, V, T])])) => Execution[A]): Trainer[K, V, T] = {
+  /**
+   * This will execute the function with the instances, sampler, and trees for
+   * the current state, ignoring the result. This can be used to spin off some
+   * side-effecting computation, such as writing a file to disk.
+   */
+  def tee(fn: ((TypedPipe[Instance[K, V, T]], Sampler[K], Iterable[(Int, Tree[K, V, T])])) => Execution[Any]): Trainer[K, V, T] = {
     val newExecution = treeExecution
       .flatMap { trees =>
         Execution.zip(trainingDataExecution, samplerExecution, trees.toIterableExecution)
@@ -57,6 +68,11 @@ case class Trainer[K: Ordering, V, T: Monoid](
     copy(trainingDataExecution = trainingDataExecution.flatMap { _.forceToDiskExecution })
   }
 
+  /**
+   * Load previously computed and stored decision trees from the path provided.
+   *
+   * @param path the path to the serialized trees
+   */
   def load(path: String)(implicit inj: Injection[Tree[K, V, T], String]): Trainer[K, V, T] = {
     copy(treeExecution = Execution.from(TypedPipe.from(TreeSource(path))))
   }
@@ -98,7 +114,8 @@ case class Trainer[K: Ordering, V, T: Monoid](
   }
 
   /**
-   * expand each tree by one level, by attempting to split every leaf.
+   * Expand each tree by one level, by attempting to split every leaf.
+   *
    * @param path where to save the new tree
    * @param splitter the splitter to use to generate candidate splits for each leaf
    * @param evaluator the evaluator to use to decide which split to use for each leaf
@@ -119,7 +136,7 @@ case class Trainer[K: Ordering, V, T: Monoid](
                 (treeIndex, tree) <- treeMap;
                 i <- 1.to(sampler.timesInTrainingSet(instance.id, instance.timestamp, treeIndex)).toList;
                 leaf <- tree.leafFor(instance.features).toList if stopper.shouldSplit(leaf.target) && stopper.shouldSplitDistributed(leaf.target);
-                (feature, stats) <- features if (sampler.includeFeature(feature, treeIndex, leaf.index))
+                (feature, stats) <- features if sampler.includeFeature(feature, treeIndex, leaf.index)
               ) yield (treeIndex, leaf.index, feature) -> stats
             }
 

--- a/brushfire-spark/pom.xml
+++ b/brushfire-spark/pom.xml
@@ -20,7 +20,8 @@
     <dependency>
       <groupId>org.apache.spark</groupId>
       <artifactId>spark-core_${scala.binary.version}</artifactId>
-      <version>1.2.0</version>
+      <version>1.2.1</version>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.stripe</groupId>
@@ -37,7 +38,7 @@
         <version>2.3</version>
         <configuration>
           <shadedArtifactAttached>false</shadedArtifactAttached>
-          <outputFile>target/brushfire-scalding-${project.version}-jar-with-dependencies.jar</outputFile>
+          <outputFile>target/brushfire-spark-${project.version}-jar-with-dependencies.jar</outputFile>
           <artifactSet>
           <includes>
             <include>*:*</include>

--- a/brushfire-spark/pom.xml
+++ b/brushfire-spark/pom.xml
@@ -1,0 +1,68 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>com.stripe</groupId>
+  <artifactId>brushfire-spark_${scala.binary.version}</artifactId>
+  <packaging>jar</packaging>
+
+  <parent>
+    <artifactId>brushfire-parent</artifactId>
+    <groupId>com.stripe</groupId>
+    <version>0.5.0-SNAPSHOT</version>
+    <relativePath>../brushfire-parent</relativePath>
+  </parent>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.scala-lang</groupId>
+      <artifactId>scala-library</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.spark</groupId>
+      <artifactId>spark-core_${scala.binary.version}</artifactId>
+      <version>1.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.stripe</groupId>
+      <artifactId>brushfire-core_${scala.binary.version}</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>2.3</version>
+        <configuration>
+          <shadedArtifactAttached>false</shadedArtifactAttached>
+          <outputFile>target/brushfire-scalding-${project.version}-jar-with-dependencies.jar</outputFile>
+          <artifactSet>
+          <includes>
+            <include>*:*</include>
+          </includes>
+        </artifactSet>
+        <filters>
+          <filter>
+            <artifact>*:*</artifact>
+            <excludes>
+                <exclude>META-INF/*.SF</exclude>
+                <exclude>META-INF/*.DSA</exclude>
+                <exclude>META-INF/*.RSA</exclude>
+            </excludes>
+          </filter>
+        </filters>
+        </configuration>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/brushfire-spark/src/main/scala/com/stripe/brushfire/spark/Example.scala
+++ b/brushfire-spark/src/main/scala/com/stripe/brushfire/spark/Example.scala
@@ -1,0 +1,83 @@
+package com.stripe.brushfire
+package spark
+
+import com.twitter.algebird.{ AveragedValue, MapMonoid, Monoid }
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.{ SparkContext, SparkConf }
+
+class TrainCSV(
+    val argv: List[String])(
+        val cols: String*)(implicit val stopper: Stopper[Map[String, Long]] = FrequencyStopper[String](10, 3)) extends Defaults with Serializable {
+  import JsonInjections._
+
+  implicit val targetMonoid: Monoid[Map[String, Long]] = new MapMonoid[String, Long] {
+    override def sumOption(items: TraversableOnce[Map[String, Long]]): Option[Map[String, Long]] =
+      super.sumOption(items).map(m => Map.empty[String, Long] ++ m)
+  }
+
+  private val error = BrierScoreError[String, Long]
+  private implicit val errorOrdering: Ordering[AveragedValue] =
+    Ordering[Double].on[AveragedValue](_.value)
+
+  private def args(key: String): String = {
+    val switch = s"--$key"
+
+    def loop(as: List[String]): String = as match {
+      case `switch` :: value :: _ => value
+      case _ :: rest => loop(rest)
+      case Nil => ???
+    }
+
+    loop(argv)
+  }
+
+  private val mkInstance: List[String] => String => Instance[String, Double, Map[String, Long]] = { cols =>
+    { line =>
+      val parts = line.split(",").reverse.toList
+      val label = parts.head
+      val values = parts.tail.map { s => s.toDouble }
+      Instance(line, 0L, Map(cols.zip(values): _*), Map(label -> 1L))
+    }
+  }
+
+  private def trainingData(context: SparkContext): RDD[Instance[String, Double, Map[String, Long]]] =
+    context
+      .textFile(args("input"))
+      .map(mkInstance(cols.toList))
+
+  def train(trainingData: RDD[Instance[String, Double, Map[String, Long]]]): Trainer[String, Double, Map[String, Long]] = {
+    Trainer(trainingData, KFoldSampler(4))
+      .expandTimes(3)
+      .expandInMemory(10)
+      .saveAsTextFile(args("output"))
+  }
+
+  def run(context: SparkContext): Unit =
+    println(train(trainingData(context)).trees.count())
+}
+
+object Iris {
+  def main(args: Array[String]): Unit = {
+    val conf = new SparkConf().setAppName("Iris")
+    val context = new SparkContext(conf)
+    new TrainCSV(args.toList)(
+      "petal-width",
+      "petal-length",
+      "sepal-width",
+      "sepal-length")
+      .run(context)
+  }
+}
+
+object Digits {
+  implicit val stopper: Stopper[Map[String, Long]] =
+    FrequencyStopper[String](200, 50)
+
+  def main(args: Array[String]): Unit = {
+    val conf = new SparkConf().setAppName("Digits")
+    val context = new SparkContext(conf)
+    val cols = 0.to(9).toList.map { "Feature" + _.toString }
+    new TrainCSV(args.toList)(cols: _*).run(context)
+  }
+}

--- a/brushfire-spark/src/main/scala/com/stripe/brushfire/spark/Trainer.scala
+++ b/brushfire-spark/src/main/scala/com/stripe/brushfire/spark/Trainer.scala
@@ -1,0 +1,108 @@
+package com.stripe.brushfire
+package spark
+
+import com.twitter.algebird._
+import com.twitter.algebird.Operators._
+
+import org.apache.spark.rdd.RDD
+import org.apache.spark.SparkContext
+import org.apache.spark.SparkContext._
+
+import scala.reflect.{ classTag, ClassTag }
+
+case class Trainer[K: Ordering, V, T: Monoid](
+    trainingData: RDD[Instance[K, V, T]],
+    sampler: Sampler[K],
+    trees: RDD[(Int, Tree[K, V, T])]) {
+  private val context: SparkContext = trainingData.context
+
+  /**
+   * Grow the trees by splitting all the leaf nodes as the stopper allows.
+   */
+  private def grow(implicit splitter: Splitter[V, T], evaluator: Evaluator[V, T], stopper: Stopper[T]): Trainer[K, V, T] = {
+    // Our bucket has a tree index, leaf index, and feature.
+    type Bucket = (Int, Int, K)
+
+    // A scored split for a particular feature.
+    type ScoredSplit = (K, Split[V, T], Double)
+
+    implicit object ScoredSplitSemigroup extends Semigroup[ScoredSplit] {
+      def plus(a: ScoredSplit, b: ScoredSplit) =
+        if (b._3 > a._3) b else a
+    }
+
+    val treeMap: scala.collection.Map[Int, Tree[K, V, T]] = trees.collectAsMap()
+
+    val collectFeatures: Instance[K, V, T] => Iterable[(Bucket, splitter.S)] = { instance =>
+      val features = instance.features.mapValues(splitter.create(_, instance.target))
+      for {
+        (treeIndex, tree) <- treeMap
+        repetition = sampler.timesInTrainingSet(instance.id, instance.timestamp, treeIndex)
+        i <- 1 to repetition
+        leaf <- tree.leafFor(instance.features).toList
+        if stopper.shouldSplit(leaf.target) && stopper.shouldSplitDistributed(leaf.target)
+        (feature, stats) <- features
+        if sampler.includeFeature(feature, treeIndex, leaf.index)
+      } yield {
+        (treeIndex, leaf.index, feature) -> stats
+      }
+    }
+
+    val split: (Bucket, splitter.S) => Iterable[(Int, Map[Int, ScoredSplit])] = { (bucket, stats) =>
+      val (treeIndex, leafIndex, feature) = bucket
+      for {
+        leaf <- treeMap(treeIndex).leafAt(leafIndex).toList
+        rawSplit <- splitter.split(leaf.target, stats)
+      } yield {
+        val (split, goodness) = evaluator.evaluate(rawSplit)
+        treeIndex -> Map(leafIndex -> (feature, split, goodness))
+      }
+    }
+
+    val emptySplits: RDD[(Int, Map[Int, ScoredSplit])] =
+      context.parallelize(Seq.tabulate(sampler.numTrees)(_ -> Map.empty[Int, ScoredSplit]))
+
+    val growTree: (Int, Map[Int, ScoredSplit]) => (Int, Tree[K, V, T]) = { (treeIndex, leafSplits) =>
+      val newTree =
+        treeMap(treeIndex)
+          .growByLeafIndex { index =>
+            for {
+              (feature, split, _) <- leafSplits.get(index).toList
+              (predicate, target) <- split.predicates
+            } yield {
+              (feature, predicate, target)
+            }
+          }
+      treeIndex -> newTree
+    }
+
+    // Ugh. We could also wrap splitter.S in some box...
+    implicit val existentialClassTag: ClassTag[splitter.S] =
+      scala.reflect.classTag[AnyRef].asInstanceOf[ClassTag[splitter.S]]
+
+    val newTrees = trainingData
+      .flatMap(collectFeatures)
+      .reduceByKey(splitter.semigroup.plus(_, _))
+      .flatMap(split.tupled)
+      .union(emptySplits)
+      .reduceByKey(_ + _)
+      .map(growTree.tupled)
+      .cache()
+
+    copy(trees = newTrees)
+  }
+}
+
+object Trainer {
+  val MaxParallelism = 20
+
+  def apply[K: Ordering, V, T: Monoid](trainingData: RDD[Instance[K, V, T]], sampler: Sampler[K]): Trainer[K, V, T] = {
+    val sc = trainingData.context
+    val initialTrees = Vector.tabulate(sampler.numTrees) { _ -> Tree.empty[K, V, T](Monoid.zero) }
+    val parallelism = scala.math.min(MaxParallelism, sampler.numTrees)
+    Trainer(
+      trainingData,
+      sampler,
+      sc.parallelize(initialTrees, parallelism))
+  }
+}

--- a/example/iris-spark
+++ b/example/iris-spark
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+$SPARK_HOME/bin/spark-submit \
+--class "com.stripe.brushfire.spark.Iris" \
+--master local[4] \
+../brushfire-spark/target/brushfire-spark-0.5.0-SNAPSHOT-jar-with-dependencies.jar \
+--input iris.data \
+--output iris-spark.output

--- a/pom.xml
+++ b/pom.xml
@@ -33,5 +33,6 @@
     <module>brushfire-parent</module>
     <module>brushfire-core</module>
     <module>brushfire-scalding</module>
+    <module>brushfire-spark</module>
   </modules>
 </project>


### PR DESCRIPTION
This isn't merge ready yet, but since I know a few other people are interested (eg @non), I figured I'd make the PR now so I can get some more eyes on it.

A few thing worth mentioning:
- Spark doesn't really have support for something like `Execution`, so we just use its strict `Unit`-happy API everywhere.
- We only write to files when explicitly asked and use `.cache()` for memoizing the trees in-between steps.
- Basically just implements `expandTimes` and `expandInMemory`, but not `prune` or `validate` (not hard, just haven't done it).
