### PR TITLE
Add max/min target tree traversal

### DIFF
--- a/brushfire-core/src/main/scala/com/stripe/brushfire/TraversalStrategy.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/TraversalStrategy.scala
@@ -151,14 +151,6 @@ final class FirstMatch[K, V, T, A] extends TraversalStrategy[K, V, T, A] {
  */
 final class MaxTargetMatch[K, V, T, A](getMaxTarget: A => Option[T])(implicit ord: Ordering[T]) extends TraversalStrategy[K, V, T, A] {
 
-  /**
-   * Let path finding short circuit if we can get the maximum target of a given
-   * node in constant time (ie from the annotaion). This requires that
-   * `maxTarget` returns the maximum target of all descendant leaf nodes.
-   */
-  def withShortCircuit(maxTarget: A => Option[T]): MaxTargetMatch[K, V, T, A] =
-    new MaxTargetMatch(maxTarget)
-
   def find(init: Node[K, V, T, A], row: Map[K, V]): Option[LeafNode[K, V, T, A]] = {
     def recur(nodes: List[Node[K, V, T, A]], max: Option[LeafNode[K, V, T, A]]): Option[LeafNode[K, V, T, A]] =
       nodes match {

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/TraversalStrategy.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/TraversalStrategy.scala
@@ -162,7 +162,12 @@ final class MaxTargetMatch[K, V, T, A](getMaxTarget: A => Option[T])(implicit or
   def find(init: Node[K, V, T, A], row: Map[K, V]): Option[LeafNode[K, V, T, A]] = {
     def recur(nodes: List[Node[K, V, T, A]], max: Option[LeafNode[K, V, T, A]]): Option[LeafNode[K, V, T, A]] =
       nodes match {
-        case Nil => max
+        case Nil =>
+          max
+        case LeafNode(_, target, _) :: rest if max.isDefined && ord.lt(target, max.get.target) =>
+          recur(rest, max)
+        case (leaf @ LeafNode(_, _, _)) :: rest =>
+          recur(rest, Some(leaf))
         case (node @ SplitNode(_)) :: rest =>
           val newMax = getMaxTarget(node.annotation) match {
             case Some(maxInPath) if max.isDefined && ord.lt(maxInPath, max.get.target) =>

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/TraversalStrategy.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/TraversalStrategy.scala
@@ -4,6 +4,8 @@ import scala.annotation.tailrec
 import scala.math.Ordering
 import scala.util.Random
 
+import com.twitter.algebird._
+
 /**
  * During a tree traversal, searching for a leaf that captures a row, there
  * are times where we have multiple successful candidate paths that can be
@@ -56,16 +58,26 @@ trait TraversalStrategy[K, V, T, A] {
         case leaf @ LeafNode(_, _, _) =>
           Some(leaf)
 
-        case SplitNode(children) =>
-          val candidates = children.collect {
-            case (key, pred, child) if pred(row.get(key)) => child
-          }.toList
-          choose(node -> candidates).flatMap(recur)
+        case split @ SplitNode(_) =>
+          choose(node -> findCandidates(split, row)).flatMap(recur)
       }
     }
 
     recur(init)
   }
+
+  /**
+   * Returns all the child nodes of `node` whose predicates are `true` for the
+   * given `row` (the candidates).
+   *
+   * @param node the split node to find the candidate children of
+   * @param row  the row being evaluated
+   * @return list of candidate child nodes of `node`
+   */
+  protected def findCandidates(node: SplitNode[K, V, T, A], row: Map[K, V]): List[Node[K, V, T, A]] =
+    node.children.collect {
+      case (key, pred, child) if pred(row.get(key)) => child
+    }.toList
 }
 
 object TraversalStrategy {
@@ -81,6 +93,46 @@ object TraversalStrategy {
   /** Returns an instance of [[MaxWeightedMatch]]. */
   def maxWeightedMatch[K, V, T, A: Ordering]: MaxWeightedMatch[K, V, T, A] =
     new MaxWeightedMatch[K, V, T, A]
+
+  /**
+   * Returns an [[TraversalStrategy]] that always chooses the candidate path
+   * that results in the largest *target* (type `T`). This may have to traverse
+   * each candidate path fully in order to find the resulting target value.
+   *
+   * Optionally, it may be possible to short-circuit some traversals if the
+   * node annotation's contain information about the maximum target in any
+   * descendant leaf nodes. This is specified by providing a `getMaxTarget`
+   * function that returns a value rather than the default of `None`.
+   *
+   * @param getMaxTarget function that returns the maximum target in a subtree
+   */
+  def maxTargetMatch[K, V, T: Ordering, A](getMaxTarget: A => Option[Max[T]] = (_: A) => None): MaxTargetMatch[K, V, T, A] =
+    new MaxTargetMatch[K, V, T, A]({ a =>
+      getMaxTarget(a) match {
+        case Some(max) => Some(max.get)
+        case None => None
+      }
+    })
+
+  /**
+   * Returns an [[TraversalStrategy]] that always chooses the candidate path
+   * that results in the smallest *target* (type `T`). This may have to traverse
+   * each candidate path fully in order to find the resulting target value.
+   *
+   * Optionally, it may be possible to short-circuit some traversals if the
+   * node annotation's contain information about the minimum target in any
+   * descendant leaf nodes. This is specified by providing a `getMinTarget`
+   * function that returns a value rather than the default of `None`.
+   *
+   * @param getMinTarget function that returns the minimum target in a subtree
+   */
+  def minTargetMatch[K, V, T: Ordering, A](getMinTarget: A => Option[Min[T]] = (_: A) => None): MaxTargetMatch[K, V, T, A] =
+    new MaxTargetMatch[K, V, T, A]({ a =>
+      getMinTarget(a) match {
+        case Some(min) => Some(min.get)
+        case None => None
+      }
+    })(Ordering[T].reverse)
 }
 
 /**
@@ -90,6 +142,52 @@ object TraversalStrategy {
 final class FirstMatch[K, V, T, A] extends TraversalStrategy[K, V, T, A] {
   def find(init: Node[K, V, T, A], row: Map[K, V]): Option[LeafNode[K, V, T, A]] =
     findMatching(init, row)(_._2.headOption)
+}
+
+/**
+ * A [[TraversalStrategy]] that will choose the path with the smallest target
+ * value. This will will always traverse all candidate paths completely, so it
+ * should be used with caution, as it could impact performance.
+ */
+final class MaxTargetMatch[K, V, T, A](getMaxTarget: A => Option[T])(implicit ord: Ordering[T]) extends TraversalStrategy[K, V, T, A] {
+
+  /**
+   * Let path finding short circuit if we can get the maximum target of a given
+   * node in constant time (ie from the annotaion). This requires that
+   * `maxTarget` returns the maximum target of all descendant leaf nodes.
+   */
+  def withShortCircuit(maxTarget: A => Option[T]): MaxTargetMatch[K, V, T, A] =
+    new MaxTargetMatch(maxTarget)
+
+  def find(init: Node[K, V, T, A], row: Map[K, V]): Option[LeafNode[K, V, T, A]] = {
+    def recur(nodes: List[Node[K, V, T, A]], max: Option[LeafNode[K, V, T, A]]): Option[LeafNode[K, V, T, A]] =
+      nodes match {
+        case Nil => max
+        case (node @ SplitNode(_)) :: rest =>
+          val newMax = getMaxTarget(node.annotation) match {
+            case Some(maxInPath) if max.isDefined && ord.lt(maxInPath, max.get.target) =>
+              // We couldn't possibly do better than max, so skip this node.
+              max
+            case _ =>
+              // Tackle the nodes with the highest potential targets first and
+              // hope this heuristic let's us avoid future traversals.
+              val childCandidates = findCandidates(node, row)
+                .sortBy(c => getMaxTarget(c.annotation))
+                .reverse
+              maxLeaf(max, recur(childCandidates, max))
+          }
+          recur(rest, newMax)
+      }
+
+    recur(init :: Nil, None)
+  }
+
+  private def maxLeaf(a: Option[LeafNode[K, V, T, A]], b: Option[LeafNode[K, V, T, A]]): Option[LeafNode[K, V, T, A]] =
+    (a, b) match {
+      case (Some(a0), Some(b0)) if ord.gteq(a0.target, b0.target) => a
+      case (_, None) => a
+      case _ => b
+    }
 }
 
 /**

--- a/brushfire-core/src/test/scala/com/stripe/brushfire/TraversalStrategySpec.scala
+++ b/brushfire-core/src/test/scala/com/stripe/brushfire/TraversalStrategySpec.scala
@@ -91,19 +91,9 @@ class TraversalStrategySpec extends WordSpec with Matchers with Checkers {
         val expectedMaxLeaf = Some(collectLeafs(maxTree.root).maxBy(_.target))
         val actualMaxLeaf = maxTree.leafFor(Map.empty, TraversalStrategy.maxTargetMatch(Some(_)))
 
-        println(s"""
-expectedMaxLeaf = $expectedMaxLeaf
-actualMaxLeaf   = $actualMaxLeaf
-""")
-
         val minTree = tree.annotate(Min(_))
         val expectedMinLeaf = Some(collectLeafs(minTree.root).minBy(_.target))
         val actualMinLeaf = minTree.leafFor(Map.empty, TraversalStrategy.minTargetMatch(Some(_)))
-
-        println(s"""
-expectedMinLeaf = $expectedMinLeaf
-actualMinLeaf   = $actualMinLeaf
-""")
 
         ("max leafs match" |: (actualMaxLeaf == expectedMaxLeaf)) &&
           ("min leafs match" |: (actualMinLeaf == expectedMinLeaf))


### PR DESCRIPTION
If working with something like a score, this let's us assume the worst/best case for a missing feature.