### PR TITLE
Use Semigroup.intTimes instead of plus'ing n times.

### DIFF
--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Splitters.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Splitters.scala
@@ -80,7 +80,7 @@ case class SpaceSaverSplitter[V, L](capacity: Int = 1000)
   val semigroup = implicitly[Semigroup[S]]
 
   def create(value: V, target: Map[L, Long]) = target.mapValues { c =>
-    Semigroup.sumOption(1L.to(c).map { i => SpaceSaver(capacity, value) }).get
+    Semigroup.intTimes(c, SpaceSaver(capacity, value))
   }
 
   def split(parent: Map[L, Long], stats: S) = {


### PR DESCRIPTION
Use `Semigroup.intTimes` when doing the initial sum of the `SpaceSaver`s in `SpaceSaverSplitter`.