### PR TITLE
brushfire-finatra: use https://maven.twttr.com

### DIFF
--- a/brushfire-finatra/build.sbt
+++ b/brushfire-finatra/build.sbt
@@ -5,7 +5,7 @@ scalaVersion in ThisBuild := "2.10.4"
 crossScalaVersions in ThisBuild := Seq("2.10.4", "2.11.5")
 
 // Required for org.apache.thrift#libthrift;0.5.0, used by Finagle.
-resolvers += "Twitter" at "http://maven.twttr.com"
+resolvers += "Twitter" at "https://maven.twttr.com"
 
 libraryDependencies += Deps.finatra
 


### PR DESCRIPTION
Switch to using HTTPS on Twitter's Maven repository