### PR TITLE
use latest jackson (1.9.13), bump brushfire version to 0.6.1

### DIFF
--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -7,7 +7,7 @@ object Resolvers {
 object Deps {
   object V {
     val algebird = "0.9.0"
-    val jackson = "1.9.2"
+    val jackson = "1.9.13"
     val bijection = "0.7.0"
 
     val hadoopClient = "2.5.2"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.6.0-SNAPSHOT"
+version in ThisBuild := "0.6.1-SNAPSHOT"


### PR DESCRIPTION
one of my brushfire jobs is failing with the following error:
```
Caused by: java.lang.NoSuchMethodError: org.codehaus.jackson.JsonNode.asText()Ljava/lang/String;
    at com.twitter.bijection.json.JsonNodeInjection$$anon$11.invert(JsonInjection.scala:108)
```

@avibryant suggested bumping jackson here.

r? @avibryant @tixxit 
