### PR TITLE
DispatchedSplitter should be a case class, consistent with other splitters.

### DIFF
--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Defaults.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Defaults.scala
@@ -4,10 +4,10 @@ import com.twitter.algebird._
 
 trait LowPriorityDefaults {
   implicit def dispatchedSplitterWithSparseBoolean[A: Ordering, B, C: Ordering, T](
-    implicit ordinal: Splitter[A, T],
-    nominal: Splitter[B, T],
-    continuous: Splitter[C, T],
-    sparse: Splitter[Boolean, T]): Splitter[Dispatched[A, B, C, Boolean], T] =
+      implicit ordinal: Splitter[A, T],
+      nominal: Splitter[B, T],
+      continuous: Splitter[C, T],
+      sparse: Splitter[Boolean, T]): Splitter[Dispatched[A, B, C, Boolean], T] =
     DispatchedSplitter(ordinal, nominal, continuous, sparse)
 }
 
@@ -21,9 +21,9 @@ trait Defaults extends LowPriorityDefaults {
   implicit def booleanSplitter[T: Group]: Splitter[Boolean, T] = SparseSplitter[Boolean, T]()
 
   implicit def dispatchedSplitterWithSpaceSaver[A: Ordering, B, C: Ordering, D, L](
-    implicit ordinal: Splitter[A, Map[L, Long]],
-    nominal: Splitter[B, Map[L, Long]],
-    continuous: Splitter[C, Map[L, Long]]): Splitter[Dispatched[A, B, C, D], Map[L, Long]] =
+      implicit ordinal: Splitter[A, Map[L, Long]],
+      nominal: Splitter[B, Map[L, Long]],
+      continuous: Splitter[C, Map[L, Long]]): Splitter[Dispatched[A, B, C, D], Map[L, Long]] =
     DispatchedSplitter(ordinal, nominal, continuous, SpaceSaverSplitter[D, L]())
 
   implicit def softVoter[L, M: Numeric]: Voter[Map[L, M], Map[L, Double]] = SoftVoter[L, M]()

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Defaults.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Defaults.scala
@@ -8,7 +8,7 @@ trait LowPriorityDefaults {
     nominal: Splitter[B, T],
     continuous: Splitter[C, T],
     sparse: Splitter[Boolean, T]): Splitter[Dispatched[A, B, C, Boolean], T] =
-    new DispatchedSplitter(ordinal, nominal, continuous, sparse)
+    DispatchedSplitter(ordinal, nominal, continuous, sparse)
 }
 
 trait Defaults extends LowPriorityDefaults {
@@ -24,7 +24,7 @@ trait Defaults extends LowPriorityDefaults {
     implicit ordinal: Splitter[A, Map[L, Long]],
     nominal: Splitter[B, Map[L, Long]],
     continuous: Splitter[C, Map[L, Long]]): Splitter[Dispatched[A, B, C, D], Map[L, Long]] =
-    new DispatchedSplitter(ordinal, nominal, continuous, SpaceSaverSplitter[D, L]())
+    DispatchedSplitter(ordinal, nominal, continuous, SpaceSaverSplitter[D, L]())
 
   implicit def softVoter[L, M: Numeric]: Voter[Map[L, M], Map[L, Double]] = SoftVoter[L, M]()
 

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
@@ -18,14 +18,12 @@ case class DispatchedSplitter[A: Ordering, B, C: Ordering, D, T](
 
   type S = Dispatched[ordinal.S, nominal.S, continuous.S, sparse.S]
   val semigroup =
-    Semigroup.from[S] { (a, b) =>
-      (a, b) match {
-        case (Ordinal(l), Ordinal(r)) => Ordinal(ordinal.semigroup.plus(l, r))
-        case (Nominal(l), Nominal(r)) => Nominal(nominal.semigroup.plus(l, r))
-        case (Continuous(l), Continuous(r)) => Continuous(continuous.semigroup.plus(l, r))
-        case (Sparse(l), Sparse(r)) => Sparse(sparse.semigroup.plus(l, r))
-        case _ => sys.error("Values do not match: " + (a, b))
-      }
+    Semigroup.from[S] {
+      case (Ordinal(l), Ordinal(r)) => Ordinal(ordinal.semigroup.plus(l, r))
+      case (Nominal(l), Nominal(r)) => Nominal(nominal.semigroup.plus(l, r))
+      case (Continuous(l), Continuous(r)) => Continuous(continuous.semigroup.plus(l, r))
+      case (Sparse(l), Sparse(r)) => Sparse(sparse.semigroup.plus(l, r))
+      case (a, b) => sys.error("Values do not match: " + (a, b))
     }
 
   def create(value: Dispatched[A, B, C, D], target: T) = {

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
@@ -9,11 +9,11 @@ case class Nominal[B](nominal: B) extends Dispatched[Nothing, B, Nothing, Nothin
 case class Continuous[C](continuous: C) extends Dispatched[Nothing, Nothing, C, Nothing]
 case class Sparse[D](sparse: D) extends Dispatched[Nothing, Nothing, Nothing, D]
 
-class DispatchedSplitter[A: Ordering, B, C: Ordering, D, T](
-  val ordinal: Splitter[A, T],
-  val nominal: Splitter[B, T],
-  val continuous: Splitter[C, T],
-  val sparse: Splitter[D, T])
+case class DispatchedSplitter[A: Ordering, B, C: Ordering, D, T](
+  ordinal: Splitter[A, T],
+  nominal: Splitter[B, T],
+  continuous: Splitter[C, T],
+  sparse: Splitter[D, T])
     extends Splitter[Dispatched[A, B, C, D], T] {
 
   type S = Dispatched[ordinal.S, nominal.S, continuous.S, sparse.S]


### PR DESCRIPTION
This also has the benefit of inheriting from `Serialized`, which is required for Spark based training and model evaluation.