### PR TITLE
Fix a build break due to a missing Semigroup constraint.

### DIFF
--- a/brushfire-finatra/src/main/scala/com/stripe/brushfire/finatra/BrushfireServer.scala
+++ b/brushfire-finatra/src/main/scala/com/stripe/brushfire/finatra/BrushfireServer.scala
@@ -1,12 +1,13 @@
 package com.stripe.brushfire.finatra
 
 import com.stripe.brushfire._
+import com.twitter.algebird.Semigroup
 import com.twitter.finatra._
 import com.twitter.finagle.http._
 import com.twitter.bijection._
 
 class BrushfireServer extends FinatraServer {
-  def score[K, V, T, P](root: String, trees: Iterable[Tree[K, V, T]], voter: Voter[T, P])(fn: ParamMap => Map[K, V]) = {
+  def score[K, V, T: Semigroup, P](root: String, trees: Iterable[Tree[K, V, T]], voter: Voter[T, P])(fn: ParamMap => Map[K, V]) = {
     register(new Controller {
       get(root) { request =>
         val row = fn(request.params)
@@ -16,7 +17,7 @@ class BrushfireServer extends FinatraServer {
     })
   }
 
-  def loadAndScore[K, V, T, P](root: String, treePath: String, voter: Voter[T, P])(fn: ParamMap => Map[K, V])(implicit inj: Injection[Tree[K, V, T], String]) = {
+  def loadAndScore[K, V, T: Semigroup, P](root: String, treePath: String, voter: Voter[T, P])(fn: ParamMap => Map[K, V])(implicit inj: Injection[Tree[K, V, T], String]) = {
     val trees = scala.io.Source.fromFile(treePath).getLines.map { line =>
       val parts = line.split("\t")
       inj.invert(parts(1)).get


### PR DESCRIPTION
Split out from one of the other pull requests. I get build failures in both IntelliJ and sbt. Fix is straightforward.

    sbt> brushfireFinatra/compile
    [info] Updating {file:/source/brushfire/}brushfireFinatra...
    [info] Resolving org.fusesource.jansi#jansi;1.4 ...
    [info] Done updating.
    [info] Compiling 2 Scala sources to /source/brushfire/brushfire-finatra/target/scala-2.10/classes...
    [error] /source/brushfire/brushfire-finatra/src/main/scala/com/stripe/brushfire/finatra/BrushfireServer.scala:13: Cannot find Semigroup type class for T
    [error]         val score = voter.predict(trees, row)
    [error]                                  ^
    [error] /source/brushfire/brushfire-finatra/src/main/scala/com/stripe/brushfire/finatra/BrushfireServer.scala:25: Cannot find Semigroup type class for T
    [error]     score[K, V, T, P](root, trees.toList, voter)(fn)
    [error]                                                 ^
    [error] (brushfireFinatra/compile:compile) Compilation failed
    [error] Total time: 1 s, completed Sep 1, 2015 4:22:41 PM
