### PR TITLE
Local mode fixes

### DIFF
--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Tree.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Tree.scala
@@ -10,33 +10,42 @@ object Tree {
 
   def singleton[K, V, T](t: T): Tree[K, V, T] = Tree(LeafNode(0, t, ()))
 
-  def expand[K, V, T: Monoid](times: Int, leaf: LeafNode[K, V, T, Unit], splitter: Splitter[V, T], evaluator: Evaluator[V, T], stopper: Stopper[T], instances: Iterable[Instance[K, V, T]]): Node[K, V, T, Unit] = {
+  def expand[K, V, T: Monoid](times: Int, treeIndex: Int, leaf: LeafNode[K, V, T, Unit], splitter: Splitter[V, T], evaluator: Evaluator[V, T], stopper: Stopper[T], sampler: Sampler[K], instances: Iterable[Instance[K, V, T]]): Node[K, V, T, Unit] = {
     if (times > 0 && stopper.shouldSplit(leaf.target)) {
       implicit val jdSemigroup = splitter.semigroup
 
       Semigroup.sumOption(instances.flatMap { instance =>
-        instance.features.map { case (f, v) => Map(f -> splitter.create(v, instance.target)) }
+        instance.features.map { case (f, v) =>
+          if(sampler.includeFeature(f, treeIndex, leaf.index))
+            Map(f -> splitter.create(v, instance.target))
+          else
+            Map.empty[K,splitter.S]
+        }
       }).flatMap { featureMap =>
         val splits = featureMap.toList.flatMap {
           case (f, s) =>
             splitter.split(leaf.target, s).map { x => f -> evaluator.evaluate(x) }
         }
 
-        val (splitFeature, (split, _)) = splits.maxBy { case (f, (x, s)) => s }
-        val edges = split.predicates.toList.map {
-          case (pred, _) =>
-            val newInstances = instances.filter { inst => pred(inst.features.get(splitFeature)) }
-            val target = Monoid.sum(newInstances.map { _.target })
-            (pred, target, newInstances)
-        }
-
-        if (edges.count { case (_, _, newInstances) => newInstances.nonEmpty } > 1) {
-          Some(SplitNode(edges.map {
-            case (pred, target, newInstances) =>
-              (splitFeature, pred, expand[K, V, T](times - 1, LeafNode(0, target), splitter, evaluator, stopper, newInstances))
-          }))
-        } else {
+        if(splits.isEmpty)
           None
+        else {
+          val (splitFeature, (split, _)) = splits.maxBy { case (f, (x, s)) => s }
+          val edges = split.predicates.toList.map {
+            case (pred, _) =>
+              val newInstances = instances.filter { inst => pred(inst.features.get(splitFeature)) }
+              val target = Monoid.sum(newInstances.map { _.target })
+              (pred, target, newInstances)
+          }
+
+          if (edges.count { case (_, _, newInstances) => newInstances.nonEmpty } > 1) {
+            Some(SplitNode(edges.map {
+              case (pred, target, newInstances) =>
+                (splitFeature, pred, expand[K, V, T](times - 1, treeIndex, LeafNode(0, target), splitter, evaluator, stopper, sampler, newInstances))
+            }))
+          } else {
+            None
+          }
         }
       }.getOrElse(leaf)
     } else {

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Trainer.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Trainer.scala
@@ -8,7 +8,7 @@ case class Trainer[K: Ordering, V, T: Monoid](
     sampler: Sampler[K],
     trees: List[Tree[K, V, T]]) {
 
-  private def updateTrees(fn: (Tree[K, V, T], Map[LeafNode[K, V, T, Unit], Iterable[Instance[K, V, T]]]) => Tree[K, V, T]): Trainer[K, V, T] = {
+  private def updateTrees(fn: (Tree[K, V, T], Int, Map[LeafNode[K, V, T, Unit], Iterable[Instance[K, V, T]]]) => Tree[K, V, T]): Trainer[K, V, T] = {
     val newTrees = trees.zipWithIndex.map {
       case (tree, index) =>
         val byLeaf =
@@ -23,17 +23,17 @@ case class Trainer[K: Ordering, V, T: Monoid](
             }
           }.groupBy { _._2 }
             .mapValues { _.map { _._1 } }
-        fn(tree, byLeaf)
+        fn(tree, index, byLeaf)
     }
     copy(trees = newTrees)
   }
 
-  private def updateLeaves(fn: (LeafNode[K, V, T, Unit], Iterable[Instance[K, V, T]]) => Node[K, V, T, Unit]): Trainer[K, V, T] = {
+  private def updateLeaves(fn: (Int, LeafNode[K, V, T, Unit], Iterable[Instance[K, V, T]]) => Node[K, V, T, Unit]): Trainer[K, V, T] = {
     updateTrees {
-      case (tree, byLeaf) =>
+      case (tree, treeIndex, byLeaf) =>
         val newNodes = byLeaf.map {
           case (leaf, instances) =>
-            leaf.index -> fn(leaf, instances)
+            leaf.index -> fn(treeIndex, leaf, instances)
         }
 
         tree.updateByLeafIndex(newNodes.lift)
@@ -42,20 +42,20 @@ case class Trainer[K: Ordering, V, T: Monoid](
 
   def updateTargets: Trainer[K, V, T] =
     updateLeaves {
-      case (leaf, instances) =>
+      case (treeIndex, leaf, instances) =>
         val target = implicitly[Monoid[T]].sum(instances.map { _.target })
         leaf.copy(target = target)
     }
 
   def expand(times: Int)(implicit splitter: Splitter[V, T], evaluator: Evaluator[V, T], stopper: Stopper[T]): Trainer[K, V, T] =
     updateLeaves {
-      case (leaf, instances) =>
-        Tree.expand(times, leaf, splitter, evaluator, stopper, instances)
+      case (treeIndex, leaf, instances) =>
+        Tree.expand(times, treeIndex, leaf, splitter, evaluator, stopper, sampler, instances)
     }
 
   def prune[P, E](error: Error[T, P, E])(implicit voter: Voter[T, P], ord: Ordering[E]): Trainer[K, V, T] =
     updateTrees {
-      case (tree, byLeaf) =>
+      case (tree, treeIndex, byLeaf) =>
         val byLeafIndex = byLeaf.map {
           case (l, instances) =>
             l.index -> implicitly[Monoid[T]].sum(instances.map { _.target })
@@ -64,13 +64,17 @@ case class Trainer[K: Ordering, V, T: Monoid](
     }
 
   def validate[P, E](error: Error[T, P, E])(implicit voter: Voter[T, P]): Option[E] = {
-    val errors = trainingData.map { instance =>
+    val errors = trainingData.flatMap { instance =>
       val useTrees = trees.zipWithIndex.filter {
         case (tree, i) =>
           sampler.includeInValidationSet(instance.id, instance.timestamp, i)
       }.map { _._1 }
-      val prediction = voter.predict(useTrees, instance.features)
-      error.create(instance.target, prediction)
+      if(useTrees.isEmpty)
+        None
+      else {
+        val prediction = voter.predict(useTrees, instance.features)
+        Some(error.create(instance.target, prediction))
+      }
     }
     error.semigroup.sumOption(errors)
   }

--- a/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Trainer.scala
+++ b/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Trainer.scala
@@ -294,7 +294,7 @@ case class Trainer[K: Ordering, V, T: Monoid](
               case ((treeIndex, leafIndex), instances) =>
                 val target = Monoid.sum(instances.map { _.target })
                 val leaf = LeafNode[K, V, T, Unit](0, target)
-                val expanded = Tree.expand(times, leaf, splitter, evaluator, stopper, instances)
+                val expanded = Tree.expand(times, treeIndex, leaf, splitter, evaluator, stopper, sampler, instances)
                 treeIndex -> List(leafIndex -> expanded)
             }
 


### PR DESCRIPTION
These are necessary to get decent performance out of the local mode.

- Tree's in-memory `expand` wasn't taking the sampler or tree id, so it couldn't correctly do feature sampling. This led to overly-correlated trees and poor performance.
- The local `validate` method was still generating (empty) predictions for instances that had been completely filtered out of the validation set (eg by the `OutOfTimeSampler`). This made performance look worse than it actually was.