### PR TITLE
Compute AUC when validating

### DIFF
--- a/brushfire-core/src/main/scala/com/stripe/brushfire/ConfusionMatrix.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/ConfusionMatrix.scala
@@ -1,0 +1,33 @@
+package com.stripe.brushfire
+
+case class ConfusionMatrix(
+  truePositives: Double,
+  trueNegatives: Double,
+  falsePositives: Double,
+  falseNegatives: Double) {
+
+  def positives = truePositives + falseNegatives
+  def negatives = trueNegatives + falsePositives
+
+  def sensitivity = truePositives / positives
+  def recall = sensitivity
+  def truePositiveRate = sensitivity
+
+  def specificity = trueNegatives / negatives
+  def trueNegativeRate = specificity
+
+  def precision = truePositives / (truePositives + falsePositives)
+  def positivePredictiveValue = precision
+
+  def negativePredictiveValue = trueNegatives / (trueNegatives + falseNegatives)
+
+  def falsePositiveRate = falsePositives / negatives
+
+  def falseDiscoveryRate = 1.0 - precision
+
+  def falseNegativeRate = falseNegatives / positives
+
+  def accuracy = (truePositives + trueNegatives) / (positives + negatives)
+
+  def f1 = (2 * truePositives) / (2 * truePositives + falsePositives + falseNegatives)
+}

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Errors.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Errors.scala
@@ -36,6 +36,38 @@ case class BrierScoreError[L, M](implicit num: Numeric[M])
   }
 }
 
+case class ConfusionMatrix(
+  truePositives: Double,
+  trueNegatives: Double,
+  falsePositives: Double,
+  falseNegatives: Double) {
+
+  def positives = truePositives + falseNegatives
+  def negatives = trueNegatives + falsePositives
+
+  def sensitivity = truePositives / positives
+  def recall = sensitivity
+  def truePositiveRate = sensitivity
+
+  def specificity = trueNegatives / negatives
+  def trueNegativeRate = specificity
+
+  def precision = truePositives / (truePositives + falsePositives)
+  def positivePredictiveValue = precision
+
+  def negativePredictiveValue = trueNegatives / (trueNegatives + falseNegatives)
+
+  def falsePositiveRate = falsePositives / negatives
+
+  def falseDiscoveryRate = 1.0 - precision
+
+  def falseNegativeRate = falseNegatives / positives
+
+  def accuracy = (truePositives + trueNegatives) / (positives + negatives)
+
+  def f1 = (2 * truePositives) / (2 * truePositives + falsePositives + falseNegatives)
+}
+
 case class BinnedBinaryError[M: Monoid]()
     extends FrequencyError[Boolean, M, Map[Int, (M, M)]] {
   lazy val monoid = implicitly[Monoid[Map[Int, (M, M)]]]
@@ -46,6 +78,23 @@ case class BinnedBinaryError[M: Monoid]()
     val tuple = if (label) (count, Monoid.zero[M]) else (Monoid.zero[M], count)
     Map(percentage(probabilities.getOrElse(true, 0.0)) -> tuple)
   }
+
+  def thresholds(err: Map[Int, (M,M)])(implicit num: Numeric[M]): List[(Int, ConfusionMatrix)] =
+    err.keys.toList.sorted.map{threshold =>
+      threshold -> ConfusionMatrix(
+        err.filter{_._1 >= threshold}.map{x => num.toDouble(x._2._1)}.sum,
+        err.filter{_._1 < threshold}.map{x => num.toDouble(x._2._2)}.sum,
+        err.filter{_._1 >= threshold}.map{x => num.toDouble(x._2._2)}.sum,
+        err.filter{_._1 < threshold}.map{x => num.toDouble(x._2._1)}.sum)
+    }
+
+  def auc(err: Map[Int, (M, M)])(implicit num: Numeric[M]) =
+    thresholds(err).map{_._2}.reverse.sliding(2,1).map{cms =>
+      val cm1 = cms(0)
+      val cm2 = cms(1)
+      (cm2.falsePositiveRate - cm1.falsePositiveRate) *
+      (cm1.truePositiveRate + cm2.truePositiveRate)
+    }.sum / 2.0
 }
 
 case class AccuracyError[L, M](implicit m: Monoid[M])

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Errors.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Errors.scala
@@ -36,38 +36,6 @@ case class BrierScoreError[L, M](implicit num: Numeric[M])
   }
 }
 
-case class ConfusionMatrix(
-  truePositives: Double,
-  trueNegatives: Double,
-  falsePositives: Double,
-  falseNegatives: Double) {
-
-  def positives = truePositives + falseNegatives
-  def negatives = trueNegatives + falsePositives
-
-  def sensitivity = truePositives / positives
-  def recall = sensitivity
-  def truePositiveRate = sensitivity
-
-  def specificity = trueNegatives / negatives
-  def trueNegativeRate = specificity
-
-  def precision = truePositives / (truePositives + falsePositives)
-  def positivePredictiveValue = precision
-
-  def negativePredictiveValue = trueNegatives / (trueNegatives + falseNegatives)
-
-  def falsePositiveRate = falsePositives / negatives
-
-  def falseDiscoveryRate = 1.0 - precision
-
-  def falseNegativeRate = falseNegatives / positives
-
-  def accuracy = (truePositives + trueNegatives) / (positives + negatives)
-
-  def f1 = (2 * truePositives) / (2 * truePositives + falsePositives + falseNegatives)
-}
-
 case class BinnedBinaryError[M: Monoid]()
     extends FrequencyError[Boolean, M, Map[Int, (M, M)]] {
   lazy val monoid = implicitly[Monoid[Map[Int, (M, M)]]]


### PR DESCRIPTION
And, more generally, get a list of ConfusionMatrix objects, one for each threshold, giving access to all the standard binary classification metrics.