### PR TITLE
sbt assembly improvements

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -24,7 +24,8 @@ lazy val root = project.
   settings(unpublished: _*)
 
 lazy val brushfireCore = project.
-  in(file("brushfire-core"))
+  in(file("brushfire-core")).
+  disablePlugins(sbtassembly.AssemblyPlugin)
 
 lazy val brushfireScalding = project.
   in(file("brushfire-scalding")).

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -29,7 +29,7 @@ object Deps {
   val jacksonJAXRS   = "org.codehaus.jackson" % "jackson-jaxrs"      % V.jackson
   val tDigest        = "com.tdunning"         % "t-digest"           % V.tDigest
 
-  val hadoopClient   = "org.apache.hadoop"    % "hadoop-client"      % V.hadoopClient
+  val hadoopClient   = "org.apache.hadoop"    % "hadoop-client"      % V.hadoopClient   % "provided"
   val scaldingCore   = "com.twitter"         %% "scalding-core"      % V.scalding
 
   val finatra        = "com.twitter"         %% "finatra"            % V.finatra

--- a/project/MakeJar.scala
+++ b/project/MakeJar.scala
@@ -5,7 +5,7 @@ import sbtassembly._
 
 object MakeJar {
   val settings = Seq(
-    jarName in assembly := name.value + "-" + version.value + "-jar-with-dependencies.jar",
+    assemblyJarName in assembly := name.value + "-" + version.value + "-jar-with-dependencies.jar",
     assemblyMergeStrategy in assembly := {
       val defaultStrategy = (assemblyMergeStrategy in assembly).value
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.9


### PR DESCRIPTION
This PR bumps sbt to the latest in the 0.13 branch and fixes three minor issues:

* The top-level assembly goal failed because `brushfire-core` does not pull in `MakeJar.settings` and thus fails to merge due to duplicate classes in minlog and kryo. I've disabled the assembly plugin for `brushfire-core` since it's not terribly useful.
* Avoids a sbt deprecation warning by changing `jarName` to `assemblyJarName`.
* Marks the hadoop related bits as `provided`, reducing the assembly jar size a bit.