### PR TITLE
Make all splits binary

### DIFF
--- a/brushfire-core/src/main/scala/com/stripe/brushfire/AnnotatedTree.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/AnnotatedTree.scala
@@ -2,24 +2,37 @@ package com.stripe.brushfire
 
 import com.twitter.algebird._
 
-sealed trait Node[K, V, T, A] {
+import java.lang.Math.{abs, max}
+
+sealed abstract class Node[K, V, T, A] {
   def annotation: A
+
+  def renumber(nextId: Int): (Int, Node[K, V, T, A]) =
+    this match {
+      case SplitNode(p, k, lc0, rc0, a) =>
+        val (n1, lc) = lc0.renumber(nextId)
+        val (n2, rc) = rc0.renumber(n1)
+        (n2, SplitNode(p, k, lc, rc, a))
+      case LeafNode(_, target, annotation) =>
+        (nextId + 1, LeafNode(nextId, target, annotation))
+    }
 }
 
-case class SplitNode[K, V, T, A: Semigroup](children: Seq[(K, Predicate[V], Node[K, V, T, A])]) extends Node[K, V, T, A] {
-  require(children.nonEmpty)
-
-  lazy val annotation: A =
-    Semigroup.sumOption(children.map(_._3.annotation)).get
-
-  def findChildren(row: Map[K, V]): List[Node[K, V, T, A]] =
-    children.collect { case (k, p, n) if p(row.get(k)) => n }(collection.breakOut)
+case class SplitNode[K, V, T, A](predicate: Predicate[V], key: K, leftChild: Node[K, V, T, A], rightChild: Node[K, V, T, A], annotation: A) extends Node[K, V, T, A] {
+  def evaluate(row: Map[K, V]): List[Node[K, V, T, A]] =
+    predicate(row.get(key)) match {
+      case Some(true) => leftChild :: Nil
+      case Some(false) => rightChild :: Nil
+      case None => leftChild :: rightChild :: Nil
+    }
 }
 
-case class LeafNode[K, V, T, A](
-  index: Int,
-  target: T,
-  annotation: A) extends Node[K, V, T, A]
+object SplitNode {
+  def apply[K, V, T, A: Semigroup](p: Predicate[V], k: K, lc: Node[K, V, T, A], rc: Node[K, V, T, A]): SplitNode[K, V, T, A] =
+    SplitNode(p, k, lc, rc, Semigroup.plus(lc.annotation, rc.annotation))
+}
+
+case class LeafNode[K, V, T, A](index: Int, target: T, annotation: A) extends Node[K, V, T, A]
 
 object LeafNode {
   def apply[K, V, T, A: Monoid](index: Int, target: T): LeafNode[K, V, T, A] =
@@ -27,51 +40,53 @@ object LeafNode {
 }
 
 case class AnnotatedTree[K, V, T, A: Semigroup](root: Node[K, V, T, A]) {
+
+  /**
+   * Transform the splits of a tree (the predicates and keys of the
+   * nodes) while leaving everything else alone.
+   */
   private def mapSplits[K0, V0](f: (K, Predicate[V]) => (K0, Predicate[V0])): AnnotatedTree[K0, V0, T, A] = {
-    def recur(node: Node[K, V, T, A]): Node[K0, V0, T, A] = node match {
-      case SplitNode(children) =>
-        SplitNode(children.map {
-          case (key, pred, child) =>
-            val (key0, pred0) = f(key, pred)
-            (key0, pred0, recur(child))
-        })
-
-      case LeafNode(index, target, annotation) =>
-        LeafNode(index, target, annotation)
+    def recur(node: Node[K, V, T, A]): Node[K0, V0, T, A] = {
+      node match {
+        case SplitNode(p, k, lc, rc, _) =>
+          val (key, pred) = f(k, p)
+          SplitNode(pred, key, recur(lc), recur(rc))
+        case LeafNode(index, target, a) =>
+          LeafNode(index, target, a)
+      }
     }
-
-    AnnotatedTree(recur(root))
-  }
-
-  private def mapLeaves[T0, A0: Semigroup](f: (T, A) => (T0, A0)): AnnotatedTree[K, V, T0, A0] = {
-    def recur(node: Node[K, V, T, A]): Node[K, V, T0, A0] = node match {
-      case SplitNode(children) =>
-        SplitNode(children.map {
-          case (key, pred, child) =>
-            (key, pred, recur(child))
-        })
-
-      case LeafNode(index, target, annotation) =>
-        val (target1, annotation1) = f(target, annotation)
-        LeafNode(index, target1, annotation1)
-    }
-
     AnnotatedTree(recur(root))
   }
 
   /**
-   * Annotate the tree by mapping the leaf target distributions to some
-   * annotation for the leaves, then bubbling the annotations up the tree using
-   * the `Semigroup` for the annotation type.
+   * Transform the leaves of a tree (the target and annotation) while
+   * leaving the structure alone.
+   */
+  private def mapLeaves[T0, A0: Semigroup](f: (T, A) => (T0, A0)): AnnotatedTree[K, V, T0, A0] = {
+    def recur(node: Node[K, V, T, A]): Node[K, V, T0, A0] = node match {
+      case SplitNode(p, k, lc, rc, _) =>
+        SplitNode(p, k, recur(lc), recur(rc))
+      case LeafNode(index, target, a) =>
+        val (target1, a1) = f(target, a)
+        LeafNode(index, target1, a1)
+    }
+    AnnotatedTree(recur(root))
+  }
+
+  /**
+   * Annotate the tree by mapping the leaf target distributions to
+   * some annotation for the leaves, then bubbling the annotations up
+   * the tree using the `Semigroup` for the annotation type.
    */
   def annotate[A1: Semigroup](f: T => A1): AnnotatedTree[K, V, T, A1] =
     mapLeaves { (t, _) => (t, f(t)) }
 
   /**
    * Re-annotate the leaves of this tree using `f` to transform the
-   * annotations. This will then bubble the annotations up the tree using the
-   * `Semigroup` for `A1`. If `f` is a semigroup homomorphism, then this
-   * (semantically) just transforms the annotation at each node using `f`.
+   * annotations. This will then bubble the annotations up the tree
+   * using the `Semigroup` for `A1`. If `f` is a semigroup
+   * homomorphism, then this (semantically) just transforms the
+   * annotation at each node using `f`.
    */
   def mapAnnotation[A1: Semigroup](f: A => A1): AnnotatedTree[K, V, T, A1] =
     mapLeaves { (t, a) => (t, f(a)) }
@@ -83,8 +98,8 @@ case class AnnotatedTree[K, V, T, A: Semigroup](root: Node[K, V, T, A]) {
     mapSplits { (k, p) => (f(k), p) }
 
   /**
-   * Maps the [[Predicate]]s in the `Tree` using `f`. Note, this will only
-   * produce a valid `Tree` if `f` preserves the ordering (ie if
+   * Maps the [[Predicate]]s in the `Tree` using `f`. Note, this will
+   * only produce a valid `Tree` if `f` preserves the ordering (ie if
    * `a.compare(b) == f(a).compare(f(b))`).
    */
   def mapPredicates[V1: Ordering](f: V => V1): AnnotatedTree[K, V1, T, A] =
@@ -93,84 +108,84 @@ case class AnnotatedTree[K, V, T, A: Semigroup](root: Node[K, V, T, A]) {
   /**
    * Returns the leaf with index `leafIndex` by performing a DFS.
    */
-  def leafAt(leafIndex: Int): Option[LeafNode[K, V, T, A]] = leafAt(leafIndex, root)
+  def leafAt(leafIndex: Int): Option[LeafNode[K, V, T, A]] =
+    leafAt(leafIndex, root)
 
   /**
-   * Returns the leaf with index `leafIndex` that is a descendant of `start` by
-   * performing a DFS starting with `start`.
+   * Returns the leaf with index `leafIndex` that is a descendant of
+   * `start` by performing a DFS starting with `start`.
    */
-  def leafAt(leafIndex: Int, start: Node[K, V, T, A]): Option[LeafNode[K, V, T, A]] = {
+  def leafAt(leafIndex: Int, start: Node[K, V, T, A]): Option[LeafNode[K, V, T, A]] =
     start match {
-      case leaf @ LeafNode(_, _, _) =>
-        if (leaf.index == leafIndex) Some(leaf) else None
-      case SplitNode(children) =>
-        children
-          .flatMap { case (_, _, child) => leafAt(leafIndex, child) }
-          .headOption
+      case SplitNode(p, k, lc, rc, _) =>
+        leafAt(leafIndex, lc) match {
+          case None => leafAt(leafIndex, rc)
+          case some => some
+        }
+      case leaf @ LeafNode(index, _, _) =>
+        if (index == leafIndex) Some(leaf) else None
     }
-  }
 
   /**
    * Prune a tree to minimize validation error.
    *
-   * Recursively replaces each split with a leaf when it would have a lower error than the sum of the child leaves
-   * errors.
+   * Recursively replaces each split with a leaf when it would have a
+   * lower error than the sum of the child leaves errors.
    *
    * @param validationData A Map from leaf index to validation data.
    * @param voter to create predictions from target distributions.
    * @param error to calculate an error statistic given observations (validation) and predictions (training).
    * @return The new, pruned tree.
    */
-  def prune[P, E](validationData: Map[Int, T], voter: Voter[T, P], error: Error[T, P, E])(implicit targetMonoid: Monoid[T], errorOrdering: Ordering[E]): AnnotatedTree[K, V, T, A] = {
-    AnnotatedTree(pruneNode(validationData, this.root, voter, error)._2).renumberLeaves
-  }
+  def prune[P, E: Ordering](validationData: Map[Int, T], voter: Voter[T, P], error: Error[T, P, E])(implicit m: Monoid[T]): AnnotatedTree[K, V, T, A] =
+    AnnotatedTree(pruneNode(validationData, root, voter, error)._2)
 
   /**
-   * Prune a tree to minimize validation error, starting from given root node.
+   * Prune a tree to minimize validation error, starting from given
+   * root node.
    *
-   * This method recursively traverses the tree from the root, branching on splits, until it finds leaves, then goes back
-   * down the tree combining leaves when such a combination would reduce validation error.
+   * This method recursively traverses the tree from the root,
+   * branching on splits, until it finds leaves, then goes back down
+   * the tree combining leaves when such a combination would reduce
+   * validation error.
    *
    * @param validationData Map from leaf index to validation data.
    * @param start The root node of the tree.
    * @return A node at the root of the new, pruned tree.
    */
-  def pruneNode[P, E](validationData: Map[Int, T], start: Node[K, V, T, A], voter: Voter[T, P], error: Error[T, P, E])(implicit targetMonoid: Monoid[T], errorOrdering: Ordering[E]): (Map[Int, T], Node[K, V, T, A]) = {
-    type ChildSeqType = (K, Predicate[V], Node[K, V, T, A])
+  def pruneNode[P, E: Ordering](validationData: Map[Int, T], start: Node[K, V, T, A], voter: Voter[T, P], error: Error[T, P, E])(implicit m: Monoid[T]): (Map[Int, T], Node[K, V, T, A]) = {
     start match {
       case leaf @ LeafNode(_, _, _) =>
         // Bounce at the bottom and start back up the tree.
         (validationData, leaf)
 
-      case SplitNode(children) =>
-        // Call pruneNode on each child, accumulating modified children and
-        // additions to the validation data along the way.
-        val (newData, newChildren) =
-          children.foldLeft((validationData, Seq[ChildSeqType]())) {
-            case ((vData, childSeq), (k, p, child)) =>
-              pruneNode(vData, child, voter, error) match {
-                case (v, c) => (v, childSeq :+ (k, p, c))
-              }
-          }
-        // Now that we've taken care of the children, prune the current level.
-        val childLeaves = newChildren.collect { case (k, v, s @ LeafNode(_, _, _)) => (k, v, s) }
+      case SplitNode(p, k, lc0, rc0, _) =>
+        val (vData, lc1) = pruneNode(validationData, lc0, voter, error)
+        val (newData, rc1) = pruneNode(vData, rc0, voter, error)
 
-        if (childLeaves.size == newChildren.size) {
-          // If all children are leaves, we can potentially prune.
-          val parent = SplitNode(newChildren)
-          pruneLevel(parent, childLeaves, newData, voter, error)
-        } else {
-          // If any children are SplitNodes, we can't prune.
-          (newData, SplitNode(newChildren))
+        // If all the children are leaves, we can potentially
+        // prune. Otherwise we definitely cannot prune.
+        lc1 match {
+          case lc2 @ LeafNode(_, _, _) =>
+            rc1 match {
+              case rc2 @ LeafNode(_, _, _) =>
+                pruneLevel(SplitNode(p, k, lc2, rc2), lc2, rc2, newData, voter, error)
+              case _ =>
+                (newData, SplitNode(p, k, lc1, rc1))
+            }
+          case _ =>
+            (newData, SplitNode(p, k, lc1, rc1))
         }
     }
   }
 
   /**
-   * Test conditions and optionally replace parent with a new leaf that combines children.
+   * Test conditions and optionally replace parent with a new leaf
+   * that combines children.
    *
-   * Also merges validation data for any combined leaves. This relies on a hack that assumes no leaves have negative
-   * indices to start out.
+   * Also merges validation data for any combined leaves. This relies
+   * on a hack that assumes no leaves have negative indices to start
+   * out.
    *
    * @param parent
    * @param children
@@ -178,31 +193,33 @@ case class AnnotatedTree[K, V, T, A: Semigroup](root: Node[K, V, T, A]) {
    */
   def pruneLevel[P, E](
     parent: SplitNode[K, V, T, A],
-    children: Seq[(K, Predicate[V], LeafNode[K, V, T, A])],
+    leftChild: LeafNode[K, V, T, A],
+    rightChild: LeafNode[K, V, T, A],
     validationData: Map[Int, T],
     voter: Voter[T, P],
-    error: Error[T, P, E])(implicit targetMonoid: Monoid[T],
-      errorOrdering: Ordering[E]): (Map[Int, T], Node[K, V, T, A]) = {
+    error: Error[T, P, E])(implicit targetMonoid: Monoid[T], errorOrdering: Ordering[E]): (Map[Int, T], Node[K, V, T, A]) = {
+
+    def v(leaf: LeafNode[K, V, T, A]): T =
+      validationData.getOrElse(leaf.index, targetMonoid.zero)
+
+    def e(leaf: LeafNode[K, V, T, A]): E =
+      error.create(v(leaf), voter.combine(Some(leaf.target)))
+
+    val targetSum = targetMonoid.plus(leftChild.target, rightChild.target)
+    val validationSum = targetMonoid.plus(v(leftChild), v(rightChild))
+    val sumOfErrors = error.semigroup.plus(e(leftChild), e(rightChild))
 
     // Get training and validation data and validation error for each leaf.
-    val (targets, validations, errors) = children.unzip3 {
-      case (k, p, leaf) =>
-        val trainingTarget = leaf.target
-        val validationTarget = validationData.getOrElse(leaf.index, targetMonoid.zero)
-        val leafError = error.create(validationTarget, voter.combine(Some(trainingTarget)))
-        (trainingTarget, validationTarget, leafError)
-    }
-
-    val targetSum = targetMonoid.sum(targets) // Combined training targets to create the training data of the potential combined node.
     val targetPrediction = voter.combine(Some(targetSum)) // Generate prediction from combined target.
-    val validationSum = targetMonoid.sum(validations) // Combined validation target for combined node.
     val errorOfSums = error.create(validationSum, targetPrediction) // Error of potential combined node.
-    val sumOfErrors = error.semigroup.sumOption(errors) // Sum of errors of leaves.
+
     // Compare sum of errors and error of sums (and lower us out of the sum of errors Option).
-    val doCombine = sumOfErrors.exists { sumOE => errorOrdering.gteq(sumOE, errorOfSums) }
-    if (doCombine) { // Create a new leaf from the combination of the children.
+    val doCombine = errorOrdering.gteq(sumOfErrors, errorOfSums)
+
+    if (doCombine) {
+      // Create a new leaf from the combination of the children.
       // Find a unique (negative) index for the new leaf:
-      val newIndex = -1 * children.map { case (k, p, leaf) => Math.abs(leaf.index) }.max
+      val newIndex = -1 * max(abs(leftChild.index), abs(rightChild.index))
       val node = LeafNode[K, V, T, A](newIndex, targetSum, parent.annotation)
       (validationData + (newIndex -> validationSum), node)
     } else {
@@ -211,48 +228,35 @@ case class AnnotatedTree[K, V, T, A: Semigroup](root: Node[K, V, T, A]) {
   }
 
   def leafFor(row: Map[K, V], id: Option[String] = None)(implicit traversal: TreeTraversal[K, V, T, A]): Option[LeafNode[K, V, T, A]] =
-    traversal.find(root, row, id).headOption
+    traversal.find(this, row, id).headOption
 
   def leafIndexFor(row: Map[K, V], id: Option[String] = None)(implicit traversal: TreeTraversal[K, V, T, A]): Option[Int] =
     leafFor(row, id).map(_.index)
 
   def targetFor(row: Map[K, V], id: Option[String] = None)(implicit traversal: TreeTraversal[K, V, T, A], semigroup: Semigroup[T]): Option[T] =
-    semigroup.sumOption(traversal.find(root, row, id).map(_.target))
+    semigroup.sumOption(traversal.find(this, row, id).map(_.target))
 
   /**
    * For each leaf, this may convert the leaf to a [[SplitNode]] whose children
    * have the target distribution returned by calling `fn` with the leaf's
    * index. If `fn` returns an empty `Seq`, then the leaf is left as-is.
    */
-  def growByLeafIndex(fn: Int => Seq[(K, Predicate[V], T, A)]): AnnotatedTree[K, V, T, A] = {
-    var newIndex = -1
-    def incrIndex(): Int = {
-      newIndex += 1
-      newIndex
-    }
-
-    def growFrom(start: Node[K, V, T, A]): Node[K, V, T, A] = {
+  def growByLeafIndex(fn: Int => Option[SplitNode[K, V, T, A]]): AnnotatedTree[K, V, T, A] = {
+    def growFrom(nextIndex: Int, start: Node[K, V, T, A]): (Int, Node[K, V, T, A]) = {
       start match {
         case LeafNode(index, target, annotation) =>
-          val newChildren = fn(index)
-          if (newChildren.isEmpty)
-            LeafNode[K, V, T, A](incrIndex(), target, annotation)
-          else
-            SplitNode[K, V, T, A](newChildren.map {
-              case (feature, predicate, target, childAnnotation) =>
-                val child = LeafNode[K, V, T, A](incrIndex(), target, childAnnotation)
-                (feature, predicate, child)
-            })
-
-        case SplitNode(children) =>
-          SplitNode[K, V, T, A](children.map {
-            case (feature, predicate, child) =>
-              (feature, predicate, growFrom(child))
-          })
+          fn(index) match {
+            case None => (nextIndex + 1, LeafNode(nextIndex, target, annotation))
+            case Some(split) => split.renumber(nextIndex)
+          }
+        case SplitNode(p, k, lc0, rc0, _) =>
+          val (n1, lc) = growFrom(nextIndex, lc0)
+          val (n2, rc) = growFrom(n1, rc0)
+          (n2, SplitNode(p, k, lc, rc))
       }
     }
 
-    AnnotatedTree(growFrom(root))
+    AnnotatedTree(growFrom(0, root)._2)
   }
 
   /**
@@ -266,11 +270,8 @@ case class AnnotatedTree[K, V, T, A: Semigroup](root: Node[K, V, T, A]) {
       start match {
         case LeafNode(index, _, _) =>
           fn(index).getOrElse(start)
-        case SplitNode(children) =>
-          SplitNode[K, V, T, A](children.map {
-            case (feature, predicate, child) =>
-              (feature, predicate, updateFrom(child))
-          })
+        case SplitNode(p, k, lc0, rc0, _) =>
+          SplitNode(p, k, updateFrom(lc0), updateFrom(rc0))
       }
     }
 
@@ -283,5 +284,5 @@ case class AnnotatedTree[K, V, T, A: Semigroup](root: Node[K, V, T, A]) {
    * @return A new tree with leaves renumbered.
    */
   def renumberLeaves: AnnotatedTree[K, V, T, A] =
-    this.growByLeafIndex { i => Nil }
+    AnnotatedTree(root.renumber(0)._2)
 }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Brushfire.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Brushfire.scala
@@ -42,17 +42,18 @@ trait Splitter[V, T] {
 }
 
 /** Candidate split for a tree node */
-sealed trait Split[V, T] {
-  def predicate: Predicate[V]
-  def leftDistribution: T
-  def rightDistribution: T
-  def distributions: List[T] = leftDistribution :: rightDistribution :: Nil
+case class Split[V, T](predicate: Predicate[V], leftDistribution: T, rightDistribution: T) {
 
+  /**
+   * Given a feature key, create a SplitNode from this Split.
+   *
+   * Note that the leaves of this node will likely need to be
+   * renumbered if this node is put into a larger tree.
+   */
   def createSplitNode[K](feature: K): SplitNode[K, V, T, Unit] =
-    SplitNode(predicate, feature, LeafNode(-1, leftDistribution), LeafNode(-1, rightDistribution))
+    SplitNode(predicate, feature, LeafNode(0, leftDistribution), LeafNode(1, rightDistribution))
 }
 
-case class BinarySplit[V, T](predicate: Predicate[V], leftDistribution: T, rightDistribution: T) extends Split[V, T]
 
 /** Evaluates the goodness of a candidate split */
 trait Evaluator[V, T] {

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Brushfire.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Brushfire.scala
@@ -42,14 +42,22 @@ trait Splitter[V, T] {
 }
 
 /** Candidate split for a tree node */
-trait Split[V, T] {
-  def predicates: Iterable[(Predicate[V], T)]
+sealed trait Split[V, T] {
+  def predicate: Predicate[V]
+  def leftDistribution: T
+  def rightDistribution: T
+  def distributions: List[T] = leftDistribution :: rightDistribution :: Nil
+
+  def createSplitNode[K](feature: K): SplitNode[K, V, T, Unit] =
+    SplitNode(predicate, feature, LeafNode(-1, leftDistribution), LeafNode(-1, rightDistribution))
 }
+
+case class BinarySplit[V, T](predicate: Predicate[V], leftDistribution: T, rightDistribution: T) extends Split[V, T]
 
 /** Evaluates the goodness of a candidate split */
 trait Evaluator[V, T] {
   /** returns a (possibly transformed) version of the input split, and a numeric goodness score */
-  def evaluate(split: Split[V, T]): (Split[V, T], Double)
+  def evaluate(split: Split[V, T]): Option[(Split[V, T], Double)]
 }
 
 /** Provides stopping conditions which guide when splits will be attempted */

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Brushfire.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Brushfire.scala
@@ -51,7 +51,7 @@ case class Split[V, T](predicate: Predicate[V], leftDistribution: T, rightDistri
    * renumbered if this node is put into a larger tree.
    */
   def createSplitNode[K](feature: K): SplitNode[K, V, T, Unit] =
-    SplitNode(predicate, feature, LeafNode(0, leftDistribution), LeafNode(1, rightDistribution))
+    SplitNode(feature, predicate, LeafNode(0, leftDistribution), LeafNode(1, rightDistribution))
 }
 
 

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
@@ -59,11 +59,7 @@ object Dispatched {
 
   def wrapSplits[X, T, A: Ordering, B, C: Ordering, D](splits: Iterable[Split[X, T]])(fn: X => Dispatched[A, B, C, D]) = {
     splits.map { split =>
-      new Split[Dispatched[A, B, C, D], T] {
-        def predicates = split.predicates.map {
-          case (pred, p) => (pred.map(fn), p)
-        }
-      }
+      BinarySplit(split.predicate.map(fn), split.leftDistribution, split.rightDistribution)
     }
   }
 }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
@@ -57,9 +57,6 @@ object Dispatched {
   def continuous[C](c: C) = Continuous(c)
   def sparse[D](d: D) = Sparse(d)
 
-  def wrapSplits[X, T, A: Ordering, B, C: Ordering, D](splits: Iterable[Split[X, T]])(fn: X => Dispatched[A, B, C, D]) = {
-    splits.map { split =>
-      BinarySplit(split.predicate.map(fn), split.leftDistribution, split.rightDistribution)
-    }
-  }
+  def wrapSplits[X, T, A: Ordering, B, C: Ordering, D](splits: Iterable[Split[X, T]])(fn: X => Dispatched[A, B, C, D]) =
+    splits.map { case Split(p, left, right) => Split(p.map(fn), left, right) }
 }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Evaluators.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Evaluators.scala
@@ -4,8 +4,8 @@ import com.twitter.algebird._
 
 case class ChiSquaredEvaluator[V, L, W](implicit weightMonoid: Monoid[W], weightDouble: W => Double)
     extends Evaluator[V, Map[L, W]] {
-  def evaluate(split: Split[V, Map[L, W]]) = {
-    val rows = split.predicates.map { _._2 }.filter { _.nonEmpty }
+  def evaluate(split: Split[V, Map[L, W]]): Option[(Split[V, Map[L, W]], Double)] = {
+    val rows = split.distributions.filter { _.nonEmpty }
     if (rows.size > 1) {
       val n = weightMonoid.sum(rows.flatMap { _.values })
       val rowTotals = rows.map { row => weightMonoid.sum(row.values) }.toList
@@ -20,43 +20,29 @@ case class ChiSquaredEvaluator[V, L, W](implicit weightMonoid: Monoid[W], weight
         val delta = observed - expected
         (delta * delta) / expected
       }).sum
-      (split, testStatistic)
-    } else
-      (EmptySplit[V, Map[L, W]](), Double.NegativeInfinity)
+      Some((split, testStatistic))
+    } else {
+      None
+    }
   }
 }
 
 case class MinWeightEvaluator[V, L, W: Monoid](minWeight: W => Boolean, wrapped: Evaluator[V, Map[L, W]])
     extends Evaluator[V, Map[L, W]] {
-  def evaluate(split: Split[V, Map[L, W]]) = {
-    val (baseSplit, baseScore) = wrapped.evaluate(split)
-    if (baseSplit.predicates.forall {
-      case (pred, freq) =>
-        val totalWeight = Monoid.sum(freq.values)
-        minWeight(totalWeight)
-    })
-      (baseSplit, baseScore)
-    else
-      (EmptySplit[V, Map[L, W]](), Double.NegativeInfinity)
-  }
-}
 
-case class EmptySplit[V, P]() extends Split[V, P] {
-  val predicates = Nil
-}
+  private[this] def test(dist: Map[L, W]): Boolean = minWeight(Monoid.sum(dist.values))
 
-case class ErrorEvaluator[V, T, P, E](error: Error[T, P, E], voter: Voter[T, P])(fn: E => Double)
-    extends Evaluator[V, T] {
-  def evaluate(split: Split[V, T]) = {
-    val totalErrorOption =
-      error.semigroup.sumOption(
-        split
-          .predicates
-          .map { case (_, target) => error.create(target, voter.combine(Some(target))) })
-
-    totalErrorOption match {
-      case Some(totalError) => (split, -fn(totalError))
-      case None => (EmptySplit[V, T](), Double.NegativeInfinity)
+  def evaluate(split: Split[V, Map[L, W]]): Option[(Split[V, Map[L, W]], Double)] =
+    wrapped.evaluate(split).filter { case (baseSplit, _) =>
+      test(baseSplit.leftDistribution) && test(baseSplit.rightDistribution)
     }
+}
+
+case class ErrorEvaluator[V, T, P, E](error: Error[T, P, E], voter: Voter[T, P])(fn: E => Double) extends Evaluator[V, T] {
+  def evaluate(split: Split[V, T]): Option[(Split[V, T], Double)] = {
+    def e(t: T): E = error.create(t, voter.combine(Some(t)))
+    val e0 = e(split.leftDistribution)
+    val e1 = e(split.rightDistribution)
+    Some((split, -fn(error.semigroup.plus(e0, e1))))
   }
 }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Splitters.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Splitters.scala
@@ -13,7 +13,7 @@ case class BinarySplitter[V, T: Monoid](partition: V => Predicate[V]) extends Sp
     stats.keys.map { v =>
       val predicate = partition(v)
       val (trues, falses) = stats.partition { case (v, d) => predicate.run(Some(v)) }
-      BinarySplit(predicate, Monoid.sum(trues.values), Monoid.sum(falses.values))
+      Split(predicate, Monoid.sum(trues.values), Monoid.sum(falses.values))
     }
   }
 }
@@ -48,7 +48,7 @@ case class QTreeSplitter[T: Monoid](k: Int)
       val predicate = LessThan(threshold)
       val leftDist = stats.rangeSumBounds(stats.lowerBound, threshold)._1
       val rightDist = stats.rangeSumBounds(threshold, stats.upperBound)._1
-      BinarySplit(predicate, leftDist, rightDist)
+      Split(predicate, leftDist, rightDist)
     }
   }
 
@@ -69,7 +69,7 @@ case class SparseSplitter[V, T: Group]() extends Splitter[V, T] {
   def create(value: V, target: T) = target
   val semigroup = implicitly[Semigroup[T]]
   def split(parent: T, stats: T) =
-    BinarySplit(IsPresent[V](None), stats, Group.minus(parent, stats)) :: Nil
+    Split(IsPresent[V](None), stats, Group.minus(parent, stats)) :: Nil
 }
 
 case class SpaceSaverSplitter[V, L](capacity: Int = 1000)
@@ -88,7 +88,7 @@ case class SpaceSaverSplitter[V, L](capacity: Int = 1000)
       .flatMap { _.counters.keys }.toSet
       .map { v: V =>
         val mins = stats.mapValues { ss => ss.frequency(v).min }
-        BinarySplit(EqualTo(v), mins, Group.minus(parent, mins))
+        Split(EqualTo(v), mins, Group.minus(parent, mins))
       }
   }
 }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Splitters.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Splitters.scala
@@ -2,8 +2,7 @@ package com.stripe.brushfire
 
 import com.twitter.algebird._
 
-case class BinarySplitter[V, T: Monoid](partition: V => Predicate[V])
-    extends Splitter[V, T] {
+case class BinarySplitter[V, T: Monoid](partition: V => Predicate[V]) extends Splitter[V, T] {
 
   type S = Map[V, T]
   def create(value: V, target: T) = Map(value -> target)
@@ -13,7 +12,7 @@ case class BinarySplitter[V, T: Monoid](partition: V => Predicate[V])
   def split(parent: T, stats: Map[V, T]) = {
     stats.keys.map { v =>
       val predicate = partition(v)
-      val (trues, falses) = stats.partition { case (v, d) => predicate(Some(v)) }
+      val (trues, falses) = stats.partition { case (v, d) => predicate.run(Some(v)) }
       BinarySplit(predicate, Monoid.sum(trues.values), Monoid.sum(falses.values))
     }
   }
@@ -92,13 +91,4 @@ case class SpaceSaverSplitter[V, L](capacity: Int = 1000)
         BinarySplit(EqualTo(v), mins, Group.minus(parent, mins))
       }
   }
-}
-
-case class BinarySplit[V, T](
-  predicate: Predicate[V],
-  leftDistribution: T,
-  rightDistribution: T)
-    extends Split[V, T] {
-  def predicates =
-    List(predicate -> leftDistribution, Not(predicate) -> rightDistribution)
 }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/TDigest.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/TDigest.scala
@@ -79,7 +79,7 @@ case class TDigestSplitter[L](k: Int = 25, compression: Double = 100.0) extends 
       // and so they can be discarded immediately
       if left.nonEmpty || right.nonEmpty
     } yield {
-      BinarySplit(LessThan(q), left, right)
+      Split(LessThan(q), left, right)
     }
 
     // if the input is not continuous or has too few examples we will end up

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Tree.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Tree.scala
@@ -37,7 +37,7 @@ object Tree {
             val target = Monoid.sum(newInstances.map(_.target))
             expand(times - 1, treeIndex, LeafNode(0, target), splitter, evaluator, stopper, sampler, newInstances)
           }
-          Some(SplitNode(pred, splitFeature, ex(left), ex(right)))
+          Some(SplitNode(splitFeature, pred, ex(left), ex(right)))
         }
       }.getOrElse(leaf)
     } else {

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Tree.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Tree.scala
@@ -31,14 +31,13 @@ object Tree {
         } yield (f, tpl)
 
         if (splits.isEmpty) None else {
-          val (splitFeature, (split, _)) = splits.maxBy { case (f, (x, s)) => s }
-          val pred = split.predicate
+          val (splitFeature, (Split(pred, left, right), _)) = splits.maxBy { case (f, (x, s)) => s }
           def ex(dist: T): Node[K, V, T, Unit] = {
             val newInstances = instances.filter { inst => pred.run(inst.features.get(splitFeature)) }
             val target = Monoid.sum(newInstances.map(_.target))
             expand(times - 1, treeIndex, LeafNode(0, target), splitter, evaluator, stopper, sampler, newInstances)
           }
-          Some(SplitNode(pred, splitFeature, ex(split.leftDistribution), ex(split.rightDistribution)))
+          Some(SplitNode(pred, splitFeature, ex(left), ex(right)))
         }
       }.getOrElse(leaf)
     } else {

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
@@ -151,7 +151,7 @@ case class DepthFirstTreeTraversal[K, V, T, A](order: (Random, List[Node[K, V, T
         case (split @ SplitNode(_, _, _, _, _)) :: rest =>
           val newStack = split.evaluate(row) match {
             case Nil => rest
-            //case node :: Nil => node :: rest
+            case node :: Nil => node :: rest
             case candidates => order(rng, candidates) ::: rest
           }
           loop(newStack)

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
@@ -148,10 +148,10 @@ case class DepthFirstTreeTraversal[K, V, T, A](order: (Random, List[Node[K, V, T
           Stream.empty
         case (leaf @ LeafNode(_, _, _)) :: rest =>
           leaf #:: loop0(rest)
-        case (split @ SplitNode(_)) :: rest =>
-          val newStack = split.findChildren(row) match {
+        case (split @ SplitNode(_, _, _, _, _)) :: rest =>
+          val newStack = split.evaluate(row) match {
             case Nil => rest
-            case node :: Nil => node :: rest
+            //case node :: Nil => node :: rest
             case candidates => order(rng, candidates) ::: rest
           }
           loop(newStack)

--- a/brushfire-core/src/test/scala/com/stripe/brushfire/JsonInjectionsSpec.scala
+++ b/brushfire-core/src/test/scala/com/stripe/brushfire/JsonInjectionsSpec.scala
@@ -15,7 +15,8 @@ class JsonInjectionsSpec extends WordSpec with Matchers with Checkers {
   "treeJsonInjection" should {
     "round-trip" in {
       check { (tree: Tree[String, Double, Map[String, Long]]) =>
-        val haggard = fromJsonNode[Tree[String, Double, Map[String, Long]]](toJsonNode(tree))
+        val json = toJsonNode(tree)
+        val haggard = fromJsonNode[Tree[String, Double, Map[String, Long]]](json)
         Try(tree) == haggard
       }
     }

--- a/brushfire-core/src/test/scala/com/stripe/brushfire/PredicateSpec.scala
+++ b/brushfire-core/src/test/scala/com/stripe/brushfire/PredicateSpec.scala
@@ -10,15 +10,15 @@ class PredicateSpec extends WordSpec with Matchers with Checkers {
     "allow missing values in all but IsPresent" in {
       check { (pred: Predicate[Int]) =>
         pred match {
-          case IsPresent(_) => pred(None) == false
-          case _ => pred(None) == true
+          case IsPresent(_) => pred.run(None) == false
+          case _ => pred.run(None) == true
         }
       }
     }
 
     "Not negates the predicate" in {
       check { (pred: Predicate[Int], value: Int) =>
-        !pred(Some(value)) == Not(pred)(Some(value))
+        !pred.run(Some(value)) == Not(pred).run(Some(value))
       }
     }
 

--- a/brushfire-core/src/test/scala/com/stripe/brushfire/TreeGenerators.scala
+++ b/brushfire-core/src/test/scala/com/stripe/brushfire/TreeGenerators.scala
@@ -39,9 +39,7 @@ object TreeGenerators {
       key <- genK
       left <- genNode(index, maxDepth - 1)
       right <- genNode(index | (1 << (maxDepth - 1)), maxDepth - 1)
-    } yield SplitNode(List(
-      (key, pred, left),
-      (key, Not(pred), right)))
+    } yield SplitNode(pred, key, left, right)
 
     def genNode(index: Int, maxDepth: Int): Gen[Node[K, V, T, Unit]] =
       if (maxDepth > 1) {

--- a/brushfire-core/src/test/scala/com/stripe/brushfire/TreeGenerators.scala
+++ b/brushfire-core/src/test/scala/com/stripe/brushfire/TreeGenerators.scala
@@ -35,11 +35,11 @@ object TreeGenerators {
       genT.map(LeafNode(index, _))
 
     def genSplit(index: Int, maxDepth: Int) = for {
-      pred <- genPredicate(genV)
       key <- genK
+      pred <- genPredicate(genV)
       left <- genNode(index, maxDepth - 1)
       right <- genNode(index | (1 << (maxDepth - 1)), maxDepth - 1)
-    } yield SplitNode(pred, key, left, right)
+    } yield SplitNode(key, pred, left, right)
 
     def genNode(index: Int, maxDepth: Int): Gen[Node[K, V, T, Unit]] =
       if (maxDepth > 1) {

--- a/brushfire-core/src/test/scala/com/stripe/brushfire/TreeTraversalSpec.scala
+++ b/brushfire-core/src/test/scala/com/stripe/brushfire/TreeTraversalSpec.scala
@@ -14,13 +14,13 @@ class TreeTraversalSpec extends WordSpec with Matchers with Checkers {
   import TreeGenerators._
 
   def split[T, A: Semigroup](key: String, pred: Predicate[Double], left: Node[String, Double, T, A], right: Node[String, Double, T, A]): SplitNode[String, Double, T, A] =
-    SplitNode(pred, key, left, right)
+    SplitNode(key, pred, left, right)
 
   "depthFirst" should {
     "always choose the left side of a split in a binary tree" in {
       val simpleTreeGen = genBinaryTree(arbitrary[String], arbitrary[Double], arbitrary[Map[String, Long]], 2)
         .filter(_.root match {
-          case SplitNode(p, _, _, _, _) =>
+          case SplitNode(_, p, _, _, _) =>
             p match {
               case IsPresent(_) => false
               case _ => true
@@ -80,7 +80,7 @@ class TreeTraversalSpec extends WordSpec with Matchers with Checkers {
 
   def collectLeafs[K, V, T, A](node: Node[K, V, T, A]): Set[LeafNode[K, V, T, A]] =
     node match {
-      case SplitNode(p, _, lc, rc, _) =>
+      case SplitNode(_, p, lc, rc, _) =>
         (if (p.run(None)) List(lc, rc) else Nil).flatMap(collectLeafs).toSet
       case leaf @ LeafNode(_, _, _) =>
         Set(leaf)


### PR DESCRIPTION
This PR simplifies brushfire's conception of split nodes (and splits) so that all decisions are binary. In practice this is almost always the case.

Some benefits of this:

1. Should drastically reduce the number of `Predicate` instances we need.
2. Avoid allocating a collection instances per split node.
3. Simplify algorithms which had to encode/decode implicit binary structure.
4. Nicer to use single concrete `Split` class.

Some drawback:

1. Different serialization format.
2. Source/binary-incompatible change.

What do you all think?