### PR TITLE
WIP: TrainingStep

### DIFF
--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
@@ -2,8 +2,11 @@ package com.stripe.brushfire.local
 
 import com.stripe.brushfire._
 import com.twitter.algebird._
+import com.twitter.bijection._
 
 object Example extends Defaults {
+
+  import JsonInjections._
 
   def main(args: Array[String]) {
     val cols = args.toList
@@ -19,13 +22,18 @@ object Example extends Defaults {
       Trainer(trainingData, KFoldSampler(4))
         .updateTargets
 
-  //  println(trainer.validate(AccuracyError()))
-  //  println(trainer.validate(BrierScoreError()))
+    println(trainer.validate(AccuracyError()))
+    println(trainer.validate(BrierScoreError()))
 
     1.to(10).foreach { i =>
       trainer = trainer.expand
-   //   println(trainer.validate(AccuracyError()))
-   //   println(trainer.validate(BrierScoreError()))
+      printTrees(trainer.trees)
+      println(trainer.validate(AccuracyError()))
+      println(trainer.validate(BrierScoreError()))
+    }
+
+    def printTrees[K,V,T](trees: List[Tree[K,V,T]])(implicit inj: Injection[Tree[K, V, T], String]) {
+      trees.foreach{tree => println(inj(tree))}
     }
 /*
     implicit val ord = Ordering.by[AveragedValue, Double] { _.value }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
@@ -19,18 +19,19 @@ object Example extends Defaults {
       Trainer(trainingData, KFoldSampler(4))
         .updateTargets
 
-    println(trainer.validate(AccuracyError()))
-    println(trainer.validate(BrierScoreError()))
+  //  println(trainer.validate(AccuracyError()))
+  //  println(trainer.validate(BrierScoreError()))
 
     1.to(10).foreach { i =>
-      trainer = trainer.expand(1)
-      println(trainer.validate(AccuracyError()))
-      println(trainer.validate(BrierScoreError()))
+      trainer = trainer.expand
+   //   println(trainer.validate(AccuracyError()))
+   //   println(trainer.validate(BrierScoreError()))
     }
-
+/*
     implicit val ord = Ordering.by[AveragedValue, Double] { _.value }
     trainer = trainer.prune(BrierScoreError())
     println(trainer.validate(AccuracyError()))
     println(trainer.validate(BrierScoreError()))
+*/
   }
 }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Trainer.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Trainer.scala
@@ -3,56 +3,139 @@ package com.stripe.brushfire.local
 import com.stripe.brushfire._
 import com.twitter.algebird._
 
+
+trait TrainingStep[K,V,T] {
+
+  type K1
+  type V1
+  type V2
+
+  def prepare(trees: Map[Int, Tree[K,V,T]], instance: Instance[K,V,T]): Seq[((Int,Int,K1), V1)]
+  def lift(tree: Tree[K,V,T], leafIndex: Int, key: K1, v1: V1): Traversable[V2]
+  def update(tree: Tree[K,V,T], map: Map[Int,V2]): Tree[K,V,T]
+
+  def semigroup1: Semigroup[V1]
+  def semigroup2: Semigroup[V2]
+  def ordering: Ordering[K1]
+}
+
+case class UpdateTargets[K,V,T](sampler: Sampler[K])(implicit val semigroup1: Semigroup[T])
+  extends TrainingStep[K,V,T] {
+
+  type K1 = Unit
+  type V1 = T
+  type V2 = T
+
+  val semigroup2 = semigroup1
+  val ordering = implicitly[Ordering[Unit]]
+
+  def prepare(trees: Map[Int, Tree[K,V,T]], instance: Instance[K,V,T]) = {
+     for (
+        (treeIndex, tree) <- trees.toList;
+        i <- 1.to(sampler.timesInTrainingSet(instance.id, instance.timestamp, treeIndex)).toList;
+        leafIndex <- tree.leafIndexFor(instance.features).toList
+      ) yield (treeIndex, leafIndex, ()) -> instance.target
+  }
+
+  def lift(tree: Tree[K,V,T], leafIndex: Int, key: K1, v1: T) = List(v1)
+
+  def update(tree: Tree[K,V,T], map: Map[Int,T]) = {
+    tree.updateByLeafIndex { index => map.get(index).map { t => LeafNode(index, t) } }
+  }
+}
+
+case class Expand[K,V,T](sampler: Sampler[K], stopper: Stopper[T], splitter: Splitter[V, T], evaluator: Evaluator[V, T])(implicit val ordering: Ordering[K])
+  extends TrainingStep[K,V,T] {
+
+  type K1 = K
+  type V1 = splitter.S
+  type V2 = (K, Split[V, T], Double)
+
+  def prepare(trees: Map[Int, Tree[K,V,T]], instance: Instance[K,V,T]) = {
+    lazy val features = instance.features.mapValues { value => splitter.create(value, instance.target) }
+
+    for
+      ((treeIndex, tree) <- trees.toList;
+      i <- 1.to(sampler.timesInTrainingSet(instance.id, instance.timestamp, treeIndex)).toList;
+      leaf <- tree.leafFor(instance.features).toList if stopper.shouldSplit(leaf.target) && stopper.shouldSplitDistributed(leaf.target);
+      (feature, stats) <- features if (sampler.includeFeature(feature, treeIndex, leaf.index)))
+        yield (treeIndex, leaf.index, feature) -> stats
+  }
+
+  def lift(tree: Tree[K,V,T], leafIndex: Int, key: K, v1: V1) = {
+    tree.leafAt(leafIndex).toList.flatMap { leaf =>
+      splitter
+        .split(leaf.target, v1)
+        .map { rawSplit =>
+          val (split, goodness) = evaluator.evaluate(rawSplit)
+          (key, split, goodness)
+        }
+    }
+  }
+
+  def update(tree: Tree[K,V,T], map: Map[Int,V2]) = {
+    tree.growByLeafIndex { index =>
+      for (
+        (feature, split, _) <- map.get(index).toList;
+        (predicate, target) <- split.predicates
+      ) yield (feature, predicate, target, ())
+    }
+  }
+
+  val semigroup1 = splitter.semigroup
+  val semigroup2 = new Semigroup[V2] {
+    def plus(a: V2, b: V2) = {
+      if (a._3 > b._3) a else b
+    }
+  }
+}
+
 case class Trainer[K: Ordering, V, T: Monoid](
     trainingData: Iterable[Instance[K, V, T]],
     sampler: Sampler[K],
     trees: List[Tree[K, V, T]]) {
 
-  private def updateTrees(fn: (Tree[K, V, T], Int, Map[LeafNode[K, V, T, Unit], Iterable[Instance[K, V, T]]]) => Tree[K, V, T]): Trainer[K, V, T] = {
-    val newTrees = trees.zipWithIndex.par.map {
-      case (tree, index) =>
-        val byLeaf =
-          trainingData.flatMap { instance =>
-            val repeats = sampler.timesInTrainingSet(instance.id, instance.timestamp, index)
-            if (repeats > 0) {
-              tree.leafFor(instance.features).map { leaf =>
-                1.to(repeats).toList.map { i => (instance, leaf) }
-              }.getOrElse(Nil)
-            } else {
-              Nil
-            }
-          }.groupBy { _._2 }
-            .mapValues { _.map { _._1 } }
-        fn(tree, index, byLeaf)
-    }
-    copy(trees = newTrees.toList)
-  }
+  def updateTrainer(step: TrainingStep[K,V,T]): Trainer[K,V,T] = {
+    val treeMap = trees.zipWithIndex.map{case (t,i) => i->t}.toMap
+    var sums1 = Map[(Int,Int,step.K1),step.V1]()
 
-  private def updateLeaves(fn: (Int, LeafNode[K, V, T, Unit], Iterable[Instance[K, V, T]]) => Node[K, V, T, Unit]): Trainer[K, V, T] = {
-    updateTrees {
-      case (tree, treeIndex, byLeaf) =>
-        val newNodes = byLeaf.map {
-          case (leaf, instances) =>
-            leaf.index -> fn(treeIndex, leaf, instances)
+    trainingData.foreach{instance =>
+      step.prepare(treeMap, instance).foreach{case (k, v1) =>
+        val combined = sums1.get(k) match {
+          case Some(old) => step.semigroup1.plus(old, v1)
+          case none => v1
         }
-
-        tree.updateByLeafIndex(newNodes.lift)
+        sums1 += k -> combined
+      }
     }
+
+    var sums2 = treeMap.mapValues{tree => Map[Int, step.V2]()}
+    sums1.foreach{case ((treeIndex, leafIndex, k), v1) =>
+      step.lift(treeMap(treeIndex), leafIndex, k, v1).foreach{v2 =>
+        val combined = sums2(treeIndex).get(leafIndex) match {
+          case Some(old) => step.semigroup2.plus(old,v2)
+          case none => v2
+        }
+        sums2 += treeIndex -> (sums2(treeIndex) + (leafIndex -> combined))
+      }
+    }
+
+    val newTreeMap = sums2.map{case (treeIndex, map) =>
+      treeIndex -> step.update(treeMap(treeIndex), sums2(treeIndex))
+    }
+
+    val newTrees = 0.until(trees.size).toList.map{i => newTreeMap(i)}
+
+    Trainer(trainingData, sampler, newTrees)
   }
 
-  def updateTargets: Trainer[K, V, T] =
-    updateLeaves {
-      case (treeIndex, leaf, instances) =>
-        val target = implicitly[Monoid[T]].sum(instances.map { _.target })
-        leaf.copy(target = target)
-    }
+  def updateTargets =
+    updateTrainer(UpdateTargets(sampler))
 
-  def expand(times: Int)(implicit splitter: Splitter[V, T], evaluator: Evaluator[V, T], stopper: Stopper[T]): Trainer[K, V, T] =
-    updateLeaves {
-      case (treeIndex, leaf, instances) =>
-        Tree.expand(times, treeIndex, leaf, splitter, evaluator, stopper, sampler, instances)
-    }
+  def expand(implicit splitter: Splitter[V, T], evaluator: Evaluator[V, T], stopper: Stopper[T]) =
+    updateTrainer(Expand(sampler, stopper, splitter, evaluator))
 
+/*
   def prune[P, E](error: Error[T, P, E])(implicit voter: Voter[T, P], ord: Ordering[E]): Trainer[K, V, T] =
     updateTrees {
       case (tree, treeIndex, byLeaf) =>
@@ -77,7 +160,7 @@ case class Trainer[K: Ordering, V, T: Monoid](
       }
     }
     error.semigroup.sumOption(errors)
-  }
+  }*/
 }
 
 object Trainer {

--- a/example/iris-local
+++ b/example/iris-local
@@ -1,5 +1,5 @@
 #!/bin/sh
-java -Xmx2G -cp ../brushfire-scalding/target/target/brushfire-scalding-0.6.0-SNAPSHOT-jar-with-dependencies.jar \
+java -Xmx2G -cp ../brushfire-scalding/target/scala-2.10/brushfire-scalding-0.6.4-SNAPSHOT-jar-with-dependencies.jar \
 com.stripe.brushfire.local.Example \
 petal-width petal-length sepal-width sepal-length \
 < iris.data


### PR DESCRIPTION
attn @tixxit @non

The intent here is to capture the basic mechanics of various training steps - updateTargets, expand, prune, etc - in a way that can be reused in multiple execution environments (local, scalding, spark, ...).

For now, this is all added directly to and used only by the Local trainer. The near-term impact is that the local trainer will stream over its input data in the same way that the distributed trainers do, rather than requiring it to all be loaded into memory. For this PR to be complete, we should move the training steps to their own module (maybe also doing https://github.com/stripe/brushfire/issues/51), and refactor the scalding trainer to use them.

It's very possible that this is too much or too little abstraction - right now it seems a bit overfit to the needs of the specific training steps and platforms we support, and I suspect it will be brittle going forward. (In fact, featureImportance already doesn't work with this, though I can argue that we should move to a TreeTraversal-based strategy for that which would). At the same time, I think *some* approach like this will be valuable going forward, and I think it's better to start going imperfectly down this path.
