### PR TITLE
WIP: rethink Evaluator

### DIFF
--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Brushfire.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Brushfire.scala
@@ -46,10 +46,9 @@ trait Split[V, T] {
   def predicates: Iterable[(Predicate[V], T)]
 }
 
-/** Evaluates the goodness of a candidate split */
-trait Evaluator[V, T] {
-  /** returns a (possibly transformed) version of the input split, and a numeric goodness score */
-  def evaluate(split: Split[V, T]): (Split[V, T], Double)
+trait Evaluator[T] {
+  /** returns an overall numeric training error for a tree or split, or None for infinite/unacceptable error */
+  def trainingError(root: T, leaves: Iterable[T]): Option[Double]
 }
 
 /** Provides stopping conditions which guide when splits will be attempted */

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Defaults.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Defaults.scala
@@ -12,7 +12,7 @@ trait LowPriorityDefaults {
 }
 
 trait Defaults extends LowPriorityDefaults {
-  implicit def chiSquaredEvaluator[V, L, W](implicit weightMonoid: Monoid[W], weightDouble: W => Double): Evaluator[V, Map[L, W]] = ChiSquaredEvaluator[V, L, W]
+  implicit def chiSquaredEvaluator[L, W](implicit weightMonoid: Monoid[W], weightDouble: W => Double): Evaluator[Map[L, W]] = ChiSquaredEvaluator[L, W]
   implicit def frequencyStopper[L]: Stopper[Map[L, Long]] = FrequencyStopper(10000, 10)
 
   implicit def intSplitter[T: Monoid]: Splitter[Int, T] = BinarySplitter[Int, T](LessThan(_))


### PR DESCRIPTION
This makes a few related changes to `Evaluator`:
- it decouples it from `Split` and just has it directly operate on `Iterable[T]`, which was the only part of a `Split` it ever cared about anyway.
- this makes it possible to apply an `Evaluator` to a tree or sub-tree, which could be useful in various ways in the future (eg if we want to change `Splitter` to produce candidate sub-trees instead of splits)
- in this context the `Iterable[T]` represents the leaves of the sub-tree, and so it's now labeled as such
- rather than using `Infinity` to represent an unacceptable level of error, it now returns `Option[Double]` so you can return `None` to signal that
- the sign has been reversed (ie this is now an error value not a "goodness" value)
- it doesn't return a new `Split`, just the error
- the root `T` is now also provided. None of the evaluators makes use of it, but there are at least two potential uses I have in mind:
    - considering a split unacceptable based on some ratio of the leaf `T` to the root `T` (eg, "all leaves must contain at least X% of the input Ys")
    - using more global optimization criteria (this comes up in particular in the "explanation tree" use case which I won't explain in more detail here)

This is WIP because I haven't fully updated the training code to make use of it.