### PR TITLE
Make Predicate[V] easier to work with.

### DIFF
--- a/brushfire-core/src/main/scala/com/stripe/brushfire/AnnotatedTree.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/AnnotatedTree.scala
@@ -27,11 +27,12 @@ sealed abstract class Node[K, V, T, A] {
 }
 
 case class SplitNode[K, V, T, A](key: K, predicate: Predicate[V], leftChild: Node[K, V, T, A], rightChild: Node[K, V, T, A], annotation: A) extends Node[K, V, T, A] {
-  def evaluate(row: Map[K, V]): List[Node[K, V, T, A]] =
-    predicate(row.get(key)) match {
-      case Some(true) => leftChild :: Nil
-      case Some(false) => rightChild :: Nil
-      case None => leftChild :: rightChild :: Nil
+  def evaluate(row: Map[K, V])(implicit ord: Ordering[V]): List[Node[K, V, T, A]] =
+    row.get(key) match {
+      case Some(v) =>
+        (if (predicate(v)) leftChild else rightChild) :: Nil
+      case None =>
+        leftChild :: rightChild :: Nil
     }
 
   def splitLabel: (K, Predicate[V], A) = (key, predicate, annotation)

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Brushfire.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Brushfire.scala
@@ -44,6 +44,9 @@ trait Splitter[V, T] {
 /** Candidate split for a tree node */
 case class Split[V, T](predicate: Predicate[V], leftDistribution: T, rightDistribution: T) {
 
+  def map[U](f: V => U): Split[U, T] =
+    Split(predicate.map(f), leftDistribution, rightDistribution)
+
   /**
    * Given a feature key, create a SplitNode from this Split.
    *

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Defaults.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Defaults.scala
@@ -2,23 +2,16 @@ package com.stripe.brushfire
 
 import com.twitter.algebird._
 
-trait LowPriorityDefaults {
-  implicit def dispatchedSplitterWithSparseBoolean[A: Ordering, B, C: Ordering, T](
-      implicit ordinal: Splitter[A, T],
-      nominal: Splitter[B, T],
-      continuous: Splitter[C, T],
-      sparse: Splitter[Boolean, T]): Splitter[Dispatched[A, B, C, Boolean], T] =
-    DispatchedSplitter(ordinal, nominal, continuous, sparse)
-}
+trait Defaults {
+  import Predicate.{ Lt, IsEq }
 
-trait Defaults extends LowPriorityDefaults {
   implicit def chiSquaredEvaluator[V, L, W](implicit weightMonoid: Monoid[W], weightDouble: W => Double): Evaluator[V, Map[L, W]] = ChiSquaredEvaluator[V, L, W]
   implicit def frequencyStopper[L]: Stopper[Map[L, Long]] = FrequencyStopper(10000, 10)
 
-  implicit def intSplitter[T: Monoid]: Splitter[Int, T] = BinarySplitter[Int, T](LessThan(_))
-  implicit def stringSplitter[T: Monoid]: Splitter[String, T] = BinarySplitter[String, T](EqualTo(_))
-  implicit def doubleSplitter[T: Monoid]: Splitter[Double, T] = BinnedSplitter(BinarySplitter[Double, T](LessThan(_))) { d => downRez(d, 2, 100) }
-  implicit def booleanSplitter[T: Group]: Splitter[Boolean, T] = SparseSplitter[Boolean, T]()
+  implicit def intSplitter[T: Monoid]: Splitter[Int, T] = BinarySplitter[Int, T](Lt(_))
+  implicit def stringSplitter[T: Monoid]: Splitter[String, T] = BinarySplitter[String, T](IsEq(_))
+  implicit def doubleSplitter[T: Monoid]: Splitter[Double, T] = BinnedSplitter(BinarySplitter[Double, T](Lt(_))) { d => downRez(d, 2, 100) }
+  implicit def booleanSplitter[T: Group]: Splitter[Boolean, T] = BinarySplitter[Boolean, T](IsEq(_))
 
   implicit def dispatchedSplitterWithSpaceSaver[A: Ordering, B, C: Ordering, D, L](
       implicit ordinal: Splitter[A, Map[L, Long]],

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
@@ -57,6 +57,5 @@ object Dispatched {
   def continuous[C](c: C) = Continuous(c)
   def sparse[D](d: D) = Sparse(d)
 
-  def wrapSplits[X, T, A: Ordering, B, C: Ordering, D](splits: Iterable[Split[X, T]])(fn: X => Dispatched[A, B, C, D]) =
-    splits.map { case Split(p, left, right) => Split(p.map(fn), left, right) }
+  def wrapSplits[X, T, A: Ordering, B, C: Ordering, D](splits: Iterable[Split[X, T]])(fn: X => Dispatched[A, B, C, D]) = splits.map(_.map(fn))
 }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Evaluators.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Evaluators.scala
@@ -31,7 +31,8 @@ case class ChiSquaredEvaluator[V, L, W](implicit weightMonoid: Monoid[W], weight
 case class MinWeightEvaluator[V, L, W: Monoid](minWeight: W => Boolean, wrapped: Evaluator[V, Map[L, W]])
     extends Evaluator[V, Map[L, W]] {
 
-  private[this] def test(dist: Map[L, W]): Boolean = minWeight(Monoid.sum(dist.values))
+  private[this] def test(dist: Map[L, W]): Boolean =
+    minWeight(Monoid.sum(dist.values))
 
   def evaluate(split: Split[V, Map[L, W]]): Option[(Split[V, Map[L, W]], Double)] =
     wrapped.evaluate(split).filter { case (Split(_, left, right), _) =>

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Predicate.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Predicate.scala
@@ -1,99 +1,141 @@
 package com.stripe.brushfire
 
 /**
- * A `Predicate` is a function given a possibly missing feature value returns
- * `true` or `false`. It is generally used within a [[Tree]] to decide which
- * branch to follow while trying to classify a row/feature vector.
+ * A `Predicate` is a function which accepts or rejects feature values.
+ *
+ * Given a value of type `V`, `apply()` will return a Boolean
+ * indicating whether the predicate matches or not. Given a
+ * possibly-missing value of type `Option[V]`, `run()` will return a
+ * Boolean indicating whether the predicate matches or not -- when a
+ * feature is missing the predicate will return true.
+ *
+ * There are six types of predicates:
+ *
+ *  - IsEq(c): x == c
+ *  - NotEq(c): x != c
+ *  - Lt(c): x < c
+ *  - LtEq(c): x <= c
+ *  - Gt(c): x > c
+ *  - GtEq(c): x >= c
+ *
+ * Predicates can be negated using `!`, and can be transformed using
+ * `map`. Evaluating a predicate requires an Ordering, but this
+ * constraint is not enforced during construction, only when `apply()`
+ * or `run()` are invoked.
  */
-sealed trait Predicate[V] extends (Option[V] => Option[Boolean]) {
+sealed abstract class Predicate[V] extends Product with Serializable {
 
-  def run(o: Option[V]): Boolean =
-    apply(o) match {
-      case Some(b) => b
-      case None => true
+  import Predicate._
+
+  /**
+   * Evaluate this predicate for the feature value `v`.
+   */
+  def apply(v: V)(implicit ord: Ordering[V]): Boolean =
+    this match {
+      case IsEq(x) => ord.equiv(v, x)
+      case NotEq(x) => !ord.equiv(v, x)
+      case Lt(x) => ord.lt(v, x)
+      case LtEq(x) => ord.lteq(v, x)
+      case Gt(x) => ord.gt(v, x)
+      case GtEq(x) => ord.gteq(v, x)
+    }
+
+  def xyz(value: Option[V], default: Option[V])(implicit ord: Ordering[V]): Boolean =
+    value match {
+      case Some(v) =>
+        this(v)
+      case None =>
+        default match {
+          case Some(v) => apply(v)
+          case None => true
+        }
+    }
+
+  // /**
+  //  * Evaluate this predicate for a possibly missing feature.
+  //  *
+  //  * If the feature is definitely present, prefer `apply()` to this
+  //  * method.
+  //  */
+  // def run(o: Option[V])(implicit ord: Ordering[V]): Boolean =
+  //   o match {
+  //     case Some(v) => this(v)
+  //     case None => true
+  //   }
+
+  /**
+   * Negate this predicate.
+   *
+   * The resulting predicate will return true in cases where this
+   * predicate returns false.
+   *
+   * (Since all predicates return true for missing features, that
+   * behavior is not negated by this method.)
+   */
+  def unary_!(): Predicate[V] =
+    this match {
+      case IsEq(v) => NotEq(v)
+      case NotEq(v) => IsEq(v)
+      case Lt(v) => GtEq(v)
+      case LtEq(v) => Gt(v)
+      case Gt(v) => LtEq(v)
+      case GtEq(v) => Lt(v)
     }
 
   /**
    * Map the value types of this [[Predicate]] using `f`.
+   *
+   * Remember that in order to evaluate a Predicate[U] you will need
+   * to be able to provide a valid Ordering[U] instance.
    */
-  def map[V1: Ordering](f: V => V1): Predicate[V1] = this match {
-    case EqualTo(v) => EqualTo(f(v))
-    case LessThan(v) => LessThan(f(v))
-    case Not(p) => Not(p.map(f))
-    case AnyOf(list) => AnyOf(list.map(_.map(f)))
-    case IsPresent(p) => IsPresent(p.map(_.map(f)))
-  }
-}
-
-/**
- * A [[Predicate]] that returns `true` iff the input is missing or the input is
- * defined and is equal to `value` (according to the input's `equals` method).
- */
-case class EqualTo[V](value: V) extends Predicate[V] {
-  def apply(v: Option[V]): Option[Boolean] = v.map(_ == value)
-}
-
-/**
- * A [[Predicate]] that returns `true` iff the input is missing or if the input
- * is defined and it is *less than* `value`. This uses the implicit `Ordering`
- * of type `V` to handle the comparison.
- */
-case class LessThan[V](value: V)(implicit ord: Ordering[V]) extends Predicate[V] {
-  def apply(v: Option[V]): Option[Boolean] = v.map(x => ord.lt(x, value))
-}
-
-/**
- * A [[Predicate]] that returns `true` if `pred` returns `false` and returns
- * `false` if `pred` returns `true`.
- */
-case class Not[V](pred: Predicate[V]) extends Predicate[V] {
-  def apply(v: Option[V]): Option[Boolean] = pred(v).map(!_)
-}
-
-/**
- * A [[Predicate]] that returns `true` if any of the predicates in `preds`
- * returns `true`.
- */
-case class AnyOf[V](preds: Seq[Predicate[V]]) extends Predicate[V] {
-  def apply(v: Option[V]): Option[Boolean] = {
-    val it = preds.iterator.map(_(v)).flatten
-    if (!it.hasNext) None else Some(it.exists(_ == true))
-  }
-}
-
-/**
- * A [[Predicate]] that will only return `true` if, at least, the value is
- * defined (not missing). Normally, predicates will treat a missing value (an
- * input of `None`) as a success and return `true`, but this is not always
- * desired. `IsPresent` allows an additional check that *requires* the value
- * be present to succeed.
- *
- * If `pred` is `None`, then this is a predicate that returns `true` iff the
- * value is present (not missing).
- */
-case class IsPresent[V](pred: Option[Predicate[V]]) extends Predicate[V] {
-  def apply(v: Option[V]): Option[Boolean] =
-    pred match {
-      case None => Some(v.isDefined)
-      case Some(pred) => Some(v.isDefined && pred(v) == Some(true))
+  def map[U](f: V => U): Predicate[U] =
+    this match {
+      case IsEq(v) => IsEq(f(v))
+      case NotEq(v) => NotEq(f(v))
+      case Lt(v) => Lt(f(v))
+      case LtEq(v) => LtEq(f(v))
+      case Gt(v) => Gt(f(v))
+      case GtEq(v) => GtEq(f(v))
     }
+
+  /**
+   * Display this predicate, using the given feature name as a
+   * placeholder.
+   */
+  def display(name: String): String =
+    this match {
+      case IsEq(v) => s"$name == $v"
+      case NotEq(v) => s"$name != $v"
+      case Lt(v) => s"$name < $v"
+      case LtEq(v) => s"$name <= $v"
+      case Gt(v) => s"$name > $v"
+      case GtEq(v) => s"$name >= $v"
+    }
+
+  /**
+   * Display this predicate as a string.
+   */
+  override def toString(): String =
+    display("x")
 }
+
 
 object Predicate {
-  def display[V](predicate: Predicate[V]): String = {
-    predicate match {
-      case EqualTo(v) => "= " + v.toString
-      case LessThan(v) => "< " + v.toString
-      case Not(EqualTo(v)) => "!= " + v.toString
-      case Not(LessThan(v)) => ">= " + v.toString
-      case AnyOf(List(LessThan(v), EqualTo(u))) => "<= " + v.toString
-      case AnyOf(List(EqualTo(v), LessThan(u))) => "<= " + v.toString
-      case Not(AnyOf(List(LessThan(v), EqualTo(u)))) => "> " + v.toString
-      case Not(AnyOf(List(EqualTo(v), LessThan(u)))) => "> " + v.toString
-      case Not(p) => "!(" + display(p) + ")"
-      case AnyOf(l) => l.map { p => "(" + display(p) + ")" }.mkString(" || ")
-      case IsPresent(None) => "exists"
-      case IsPresent(Some(pred)) => "(exists && (" + display(pred) + "))"
-    }
-  }
+
+  // specific predicate types
+  case class IsEq[V](value: V) extends Predicate[V]
+  case class NotEq[V](value: V) extends Predicate[V]
+  case class Lt[V](value: V) extends Predicate[V]
+  case class LtEq[V](value: V) extends Predicate[V]
+  case class Gt[V](value: V) extends Predicate[V]
+  case class GtEq[V](value: V) extends Predicate[V]
+
+  // predicate factory constructors, to help fix the correct return
+  // type (Predicate[V]).
+  def isEq[V](x: V): Predicate[V] = IsEq(x)
+  def notEq[V](x: V): Predicate[V] = NotEq(x)
+  def lt[V](x: V): Predicate[V] = Lt(x)
+  def ltEq[V](x: V): Predicate[V] = LtEq(x)
+  def gt[V](x: V): Predicate[V] = Gt(x)
+  def gtEq[V](x: V): Predicate[V] = GtEq(x)
 }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Predicate.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Predicate.scala
@@ -4,10 +4,7 @@ package com.stripe.brushfire
  * A `Predicate` is a function which accepts or rejects feature values.
  *
  * Given a value of type `V`, `apply()` will return a Boolean
- * indicating whether the predicate matches or not. Given a
- * possibly-missing value of type `Option[V]`, `run()` will return a
- * Boolean indicating whether the predicate matches or not -- when a
- * feature is missing the predicate will return true.
+ * indicating whether the predicate matches or not.
  *
  * There are six types of predicates:
  *
@@ -21,7 +18,7 @@ package com.stripe.brushfire
  * Predicates can be negated using `!`, and can be transformed using
  * `map`. Evaluating a predicate requires an Ordering, but this
  * constraint is not enforced during construction, only when `apply()`
- * or `run()` are invoked.
+ * is invoked.
  */
 sealed abstract class Predicate[V] extends Product with Serializable {
 
@@ -39,29 +36,6 @@ sealed abstract class Predicate[V] extends Product with Serializable {
       case Gt(x) => ord.gt(v, x)
       case GtEq(x) => ord.gteq(v, x)
     }
-
-  def xyz(value: Option[V], default: Option[V])(implicit ord: Ordering[V]): Boolean =
-    value match {
-      case Some(v) =>
-        this(v)
-      case None =>
-        default match {
-          case Some(v) => apply(v)
-          case None => true
-        }
-    }
-
-  // /**
-  //  * Evaluate this predicate for a possibly missing feature.
-  //  *
-  //  * If the feature is definitely present, prefer `apply()` to this
-  //  * method.
-  //  */
-  // def run(o: Option[V])(implicit ord: Ordering[V]): Boolean =
-  //   o match {
-  //     case Some(v) => this(v)
-  //     case None => true
-  //   }
 
   /**
    * Negate this predicate.

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Splitters.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Splitters.scala
@@ -2,17 +2,17 @@ package com.stripe.brushfire
 
 import com.twitter.algebird._
 
-case class BinarySplitter[V, T: Monoid](partition: V => Predicate[V]) extends Splitter[V, T] {
+case class BinarySplitter[V: Ordering, T: Monoid](partition: V => Predicate[V]) extends Splitter[V, T] {
 
   type S = Map[V, T]
   def create(value: V, target: T) = Map(value -> target)
 
   val semigroup = implicitly[Semigroup[Map[V, T]]]
 
-  def split(parent: T, stats: Map[V, T]) = {
+  def split(parent: T, stats: Map[V, T]): Iterable[Split[V, T]] = {
     stats.keys.map { v =>
       val predicate = partition(v)
-      val (trues, falses) = stats.partition { case (v, d) => predicate.run(Some(v)) }
+      val (trues, falses) = stats.partition { case (v, d) => predicate(v) }
       Split(predicate, Monoid.sum(trues.values), Monoid.sum(falses.values))
     }
   }
@@ -23,7 +23,7 @@ case class RandomSplitter[V, T](original: Splitter[V, T])
   type S = original.S
   val semigroup = original.semigroup
   def create(value: V, target: T) = original.create(value, target)
-  def split(parent: T, stats: S) =
+  def split(parent: T, stats: S): Iterable[Split[V, T]] =
     scala.util.Random.shuffle(original.split(parent, stats)).headOption
 }
 
@@ -32,7 +32,8 @@ case class BinnedSplitter[V, T](original: Splitter[V, T])(fn: V => V)
   type S = original.S
   def create(value: V, target: T) = original.create(fn(value), target)
   val semigroup = original.semigroup
-  def split(parent: T, stats: S) = original.split(parent, stats)
+  def split(parent: T, stats: S): Iterable[Split[V, T]] =
+    original.split(parent, stats)
 }
 
 case class QTreeSplitter[T: Monoid](k: Int)
@@ -43,9 +44,9 @@ case class QTreeSplitter[T: Monoid](k: Int)
   val semigroup = new QTreeSemigroup[T](k)
   def create(value: Double, target: T) = QTree(value -> target)
 
-  def split(parent: T, stats: QTree[T]) = {
+  def split(parent: T, stats: QTree[T]): Iterable[Split[Double, T]] = {
     findAllThresholds(stats).map { threshold =>
-      val predicate = LessThan(threshold)
+      val predicate = Predicate.Lt(threshold)
       val leftDist = stats.rangeSumBounds(stats.lowerBound, threshold)._1
       val rightDist = stats.rangeSumBounds(threshold, stats.upperBound)._1
       Split(predicate, leftDist, rightDist)
@@ -64,14 +65,6 @@ case class QTreeSplitter[T: Monoid](k: Int)
   }
 }
 
-case class SparseSplitter[V, T: Group]() extends Splitter[V, T] {
-  type S = T
-  def create(value: V, target: T) = target
-  val semigroup = implicitly[Semigroup[T]]
-  def split(parent: T, stats: T) =
-    Split(IsPresent[V](None), stats, Group.minus(parent, stats)) :: Nil
-}
-
 case class SpaceSaverSplitter[V, L](capacity: Int = 1000)
     extends Splitter[V, Map[L, Long]] {
 
@@ -82,13 +75,12 @@ case class SpaceSaverSplitter[V, L](capacity: Int = 1000)
     Semigroup.intTimes(c, SpaceSaver(capacity, value))
   }
 
-  def split(parent: Map[L, Long], stats: S) = {
+  def split(parent: Map[L, Long], stats: S): Iterable[Split[V, Map[L, Long]]] =
     stats
       .values
-      .flatMap { _.counters.keys }.toSet
-      .map { v: V =>
+      .flatMap(_.counters.keys).toSet
+      .map { (v: V) =>
         val mins = stats.mapValues { ss => ss.frequency(v).min }
-        Split(EqualTo(v), mins, Group.minus(parent, mins))
+        Split(Predicate.isEq(v), mins, Group.minus(parent, mins))
       }
-  }
 }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/TDigest.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/TDigest.scala
@@ -3,6 +3,8 @@ package com.stripe.brushfire
 import com.tdunning.math.stats.TDigest
 import com.twitter.algebird.{Monoid, Semigroup}
 
+import Predicate.Lt
+
 private [this] case object TDigestSemigroup extends Semigroup[TDigest] {
   override def plus(l: TDigest, r: TDigest): TDigest = {
     val td = TDigest.createDigest(math.max(l.compression(), r.compression()))
@@ -79,7 +81,7 @@ case class TDigestSplitter[L](k: Int = 25, compression: Double = 100.0) extends 
       // and so they can be discarded immediately
       if left.nonEmpty || right.nonEmpty
     } yield {
-      Split(LessThan(q), left, right)
+      Split(Lt(q), left, right)
     }
 
     // if the input is not continuous or has too few examples we will end up

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Trainer.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Trainer.scala
@@ -6,7 +6,7 @@ import com.twitter.algebird._
 
 import AnnotatedTree.AnnotatedTreeTraversal
 
-case class Trainer[K: Ordering, V, T: Monoid](
+case class Trainer[K: Ordering, V: Ordering, T: Monoid](
     trainingData: Iterable[Instance[K, V, T]],
     sampler: Sampler[K],
     trees: List[Tree[K, V, T]])(implicit traversal: AnnotatedTreeTraversal[K, V, T, Unit]) {
@@ -54,7 +54,7 @@ case class Trainer[K: Ordering, V, T: Monoid](
   def expand(times: Int)(implicit splitter: Splitter[V, T], evaluator: Evaluator[V, T], stopper: Stopper[T]): Trainer[K, V, T] =
     updateLeaves {
       case (treeIndex, (index, target, annotation), instances) =>
-        Tree.expand(times, treeIndex, LeafNode(index, target, annotation), splitter, evaluator, stopper, sampler, instances)
+        Tree.expand(times, treeIndex, LeafNode[K, V, T, Unit](index, target, annotation), splitter, evaluator, stopper, sampler, instances)
     }
 
   def prune[P, E](error: Error[T, P, E])(implicit voter: Voter[T, P], ord: Ordering[E]): Trainer[K, V, T] =
@@ -85,7 +85,7 @@ case class Trainer[K: Ordering, V, T: Monoid](
 }
 
 object Trainer {
-  def apply[K: Ordering, V, T: Monoid](trainingData: Iterable[Instance[K, V, T]], sampler: Sampler[K])(implicit traversal: AnnotatedTreeTraversal[K, V, T, Unit]): Trainer[K, V, T] = {
+  def apply[K: Ordering, V: Ordering, T: Monoid](trainingData: Iterable[Instance[K, V, T]], sampler: Sampler[K])(implicit traversal: AnnotatedTreeTraversal[K, V, T, Unit]): Trainer[K, V, T] = {
     val empty = 0.until(sampler.numTrees).toList.map { i => Tree.singleton[K, V, T](Monoid.zero) }
     Trainer(trainingData, sampler, empty)
   }

--- a/brushfire-core/src/test/scala/com/stripe/brushfire/PredicateSpec.scala
+++ b/brushfire-core/src/test/scala/com/stripe/brushfire/PredicateSpec.scala
@@ -7,26 +7,20 @@ class PredicateSpec extends WordSpec with Matchers with Checkers {
   import PredicateGenerators._
 
   "Predicate" should {
-    "allow missing values in all but IsPresent" in {
-      check { (pred: Predicate[Int]) =>
-        pred match {
-          case IsPresent(_) => pred.run(None) == false
-          case _ => pred.run(None) == true
-        }
-      }
+    "!(p(x)) = (!p)(x)" in {
+      check { (p: Predicate[Int], x: Int) => !p(x) == (!p).apply(x) }
     }
 
-    "Not negates the predicate" in {
-      check { (pred: Predicate[Int], value: Int) =>
-        !pred.run(Some(value)) == Not(pred).run(Some(value))
-      }
+    "!(!p) = p" in {
+      check { (pred: Predicate[Int]) => !(!pred) == pred }
     }
 
     "can be displayed" in {
-      check { (pred: Predicate[Int]) =>
-        // We really just don't want it to blow up.
-        Predicate.display(pred) != null
-      }
+      check { (p: Predicate[Int]) => p.display("x") != null }
+    }
+
+    "p.map(f)(y) = p(f(y))" in {
+
     }
   }
 }

--- a/brushfire-core/src/test/scala/com/stripe/brushfire/TreeGenerators.scala
+++ b/brushfire-core/src/test/scala/com/stripe/brushfire/TreeGenerators.scala
@@ -5,23 +5,16 @@ import com.twitter.algebird.Semigroup
 import org.scalacheck.{ Gen, Arbitrary }
 import org.scalacheck.Arbitrary.arbitrary
 
+import Predicate.{ isEq, notEq, lt, ltEq, gt, gtEq }
+
 object PredicateGenerators {
   val MaxPredicateDepth = 2
 
-  implicit def arbPredicate[V: Arbitrary: Ordering]: Arbitrary[Predicate[V]] =
+  implicit def arbPredicate[V: Arbitrary]: Arbitrary[Predicate[V]] =
     Arbitrary(genPredicate(arbitrary[V]))
 
-  def genPredicate[V: Ordering](genV: Gen[V], depth: Int = 1): Gen[Predicate[V]] =
-    if (depth >= MaxPredicateDepth) {
-      Gen.oneOf(genV.map(EqualTo(_)), genV.map(LessThan(_)))
-    } else {
-      Gen.oneOf[Predicate[V]](
-        genV.map(EqualTo(_)),
-        genV.map(LessThan(_)),
-        genPredicate(genV, depth + 1).map(Not(_)),
-        Gen.nonEmptyListOf(genPredicate(genV, depth + 1)).map(AnyOf(_)),
-        Gen.option(genPredicate(genV, depth + 1)).map(IsPresent(_)))
-    }
+  def genPredicate[V](g: Gen[V]): Gen[Predicate[V]] =
+    Gen.oneOf(g.map(isEq), g.map(notEq), g.map(lt), g.map(ltEq), g.map(gt), g.map(gtEq))
 }
 
 object TreeGenerators {

--- a/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Trainer.scala
+++ b/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Trainer.scala
@@ -21,7 +21,7 @@ object TreeSource {
   }
 }
 
-case class Trainer[K: Ordering, V, T: Monoid](
+case class Trainer[K: Ordering, V: Ordering, T: Monoid](
     @transient trainingDataExecution: Execution[TypedPipe[Instance[K, V, T]]],
     @transient samplerExecution: Execution[Sampler[K]],
     @transient treeExecution: Execution[TypedPipe[(Int, Tree[K, V, T])]],
@@ -335,7 +335,7 @@ case class Trainer[K: Ordering, V, T: Monoid](
 object Trainer {
   val MaxReducers = 20
 
-  def apply[K: Ordering, V, T: Monoid](trainingData: TypedPipe[Instance[K, V, T]], sampler: Sampler[K]): Trainer[K, V, T] = {
+  def apply[K: Ordering, V: Ordering, T: Monoid](trainingData: TypedPipe[Instance[K, V, T]], sampler: Sampler[K]): Trainer[K, V, T] = {
     val empty = 0.until(sampler.numTrees).map { treeIndex => (treeIndex, Tree.singleton[K, V, T](Monoid.zero)) }
     Trainer(
       Execution.from(trainingData),


### PR DESCRIPTION
In line with the move toward binary splits, we can simplify our
predicates to make them easier to work with. Previously we've relied a
lot on ad-hoc encodings, (such as `Not(LessThan(_))` and
`OneOf(LessThan(_), EqualTo(_))`).

This commit replaces the previous predicate hierarchy with a set of
six non-recursive predicate types:

 - IsEq
 - NotEq
 - Lt
 - LtEq
 - Gt
 - GtEq

Predicates will display themselves in a more friendly format, which
should make them easier to work with. They also now come with a
negation operator (!p) which should remove the necessity of
creating/matching Not(_) nodes in user code.

The Ordering[V] requirement is moved from the Predicate[V]
constructors into the apply() and run() methods. This will reduce the
memory use for predicates, and also simplifies the serialization code.

The support for IsPresent(_) has also been removed. If you want
missing values to be treated specially (i.e. treated as just matching
or not matching), you'll need to arrange for that to happen before the
row value is constructed. Future work might generalize rows from
Map[K, V] to (K => V) to make this process more efficient.

?r by @tixxit, @avibryant, and/or @jvns.