### PR TITLE
Require full orderings for nominal/sparse

### DIFF
--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
@@ -44,10 +44,17 @@ case class DispatchedSplitter[A: Ordering, B, C: Ordering, D, T](
 }
 
 object Dispatched {
-  implicit def ordering[A, B, C, D](implicit ordinalOrdering: Ordering[A], continuousOrdering: Ordering[C]): Ordering[Dispatched[A, B, C, D]] = new Ordering[Dispatched[A, B, C, D]] {
+  implicit def ordering[A, B, C, D](implicit
+    ordinalOrdering: Ordering[A],
+    nominalOrdering: Ordering[B],
+    continuousOrdering: Ordering[C],
+    sparseOrdering: Ordering[D]
+  ): Ordering[Dispatched[A, B, C, D]] = new Ordering[Dispatched[A, B, C, D]] {
     def compare(left: Dispatched[A, B, C, D], right: Dispatched[A, B, C, D]) = (left, right) match {
       case (Ordinal(l), Ordinal(r)) => ordinalOrdering.compare(l, r)
+      case (Nominal(l), Nominal(r)) => nominalOrdering.compare(l, r)
       case (Continuous(l), Continuous(r)) => continuousOrdering.compare(l, r)
+      case (Sparse(l), Sparse(r)) => sparseOrdering.compare(l, r)
       case _ => sys.error("Values cannot be compared: " + (left, right))
     }
   }


### PR DESCRIPTION
Now that we *always* use `Ordering[V]` for all predicate comparisons, we need Dispatched's Ordering to actually handle nominal/sparse cases. This isn't the best solution, since it restricts our nominal/sparse types unnecessarily, but is meant as a stopgap until we switch to using PartialOrderings.