### PR TITLE
Use partial order to support different split behaviors

### DIFF
--- a/brushfire-core/build.sbt
+++ b/brushfire-core/build.sbt
@@ -11,6 +11,7 @@ libraryDependencies ++= {
     jacksonXC,
     jacksonJAXRS,
     tDigest,
+    spire,
     scalaTest,
     scalaCheck
   )

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/AnnotatedTree.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/AnnotatedTree.scala
@@ -2,6 +2,7 @@ package com.stripe.brushfire
 
 import com.twitter.algebird._
 import com.stripe.bonsai.{ FullBinaryTree, FullBinaryTreeOps }
+import spire.algebra.PartialOrder
 
 import java.lang.Math.{abs, max}
 
@@ -27,7 +28,7 @@ sealed abstract class Node[K, V, T, A] {
 }
 
 case class SplitNode[K, V, T, A](key: K, predicate: Predicate[V], leftChild: Node[K, V, T, A], rightChild: Node[K, V, T, A], annotation: A) extends Node[K, V, T, A] {
-  def evaluate(row: Map[K, V])(implicit ord: Ordering[V]): List[Node[K, V, T, A]] =
+  def evaluate(row: Map[K, V])(implicit ord: PartialOrder[V]): List[Node[K, V, T, A]] =
     row.get(key) match {
       case Some(v) =>
         (if (predicate(v)) leftChild else rightChild) :: Nil

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/AnnotatedTree.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/AnnotatedTree.scala
@@ -2,7 +2,8 @@ package com.stripe.brushfire
 
 import com.twitter.algebird._
 import com.stripe.bonsai.{ FullBinaryTree, FullBinaryTreeOps }
-import spire.algebra.PartialOrder
+import spire.algebra.{ Order, PartialOrder }
+import spire.syntax.all._
 
 import java.lang.Math.{abs, max}
 
@@ -118,7 +119,7 @@ case class AnnotatedTree[K, V, T, A](root: Node[K, V, T, A]) {
    * only produce a valid `Tree` if `f` preserves the ordering (ie if
    * `a.compare(b) == f(a).compare(f(b))`).
    */
-  def mapPredicates[V1: Ordering](f: V => V1): AnnotatedTree[K, V1, T, A] =
+  def mapPredicates[V1](f: V => V1): AnnotatedTree[K, V1, T, A] =
     mapSplits { (k, p) => (k, p.map(f)) }
 
   /**
@@ -153,7 +154,7 @@ case class AnnotatedTree[K, V, T, A](root: Node[K, V, T, A]) {
    * @param error to calculate an error statistic given observations (validation) and predictions (training).
    * @return The new, pruned tree.
    */
-  def prune[P, E: Ordering](validationData: Map[Int, T], voter: Voter[T, P], error: Error[T, P, E])(implicit m: Monoid[T], s: Semigroup[A]): AnnotatedTree[K, V, T, A] =
+  def prune[P, E: Order](validationData: Map[Int, T], voter: Voter[T, P], error: Error[T, P, E])(implicit m: Monoid[T], s: Semigroup[A]): AnnotatedTree[K, V, T, A] =
     AnnotatedTree(pruneNode(validationData, root, voter, error)._2)
 
   /**
@@ -169,7 +170,7 @@ case class AnnotatedTree[K, V, T, A](root: Node[K, V, T, A]) {
    * @param start The root node of the tree.
    * @return A node at the root of the new, pruned tree.
    */
-  def pruneNode[P, E: Ordering](validationData: Map[Int, T], start: Node[K, V, T, A], voter: Voter[T, P], error: Error[T, P, E])(implicit m: Monoid[T], aSemigroup: Semigroup[A]): (Map[Int, T], Node[K, V, T, A]) = {
+  def pruneNode[P, E: Order](validationData: Map[Int, T], start: Node[K, V, T, A], voter: Voter[T, P], error: Error[T, P, E])(implicit m: Monoid[T], aSemigroup: Semigroup[A]): (Map[Int, T], Node[K, V, T, A]) = {
     start match {
       case leaf @ LeafNode(_, _, _) =>
         // Bounce at the bottom and start back up the tree.
@@ -207,13 +208,13 @@ case class AnnotatedTree[K, V, T, A](root: Node[K, V, T, A]) {
    * @param children
    * @return
    */
-  def pruneLevel[P, E](
+  def pruneLevel[P, E: Order](
     parent: SplitNode[K, V, T, A],
     leftChild: LeafNode[K, V, T, A],
     rightChild: LeafNode[K, V, T, A],
     validationData: Map[Int, T],
     voter: Voter[T, P],
-    error: Error[T, P, E])(implicit targetMonoid: Monoid[T], errorOrdering: Ordering[E]): (Map[Int, T], Node[K, V, T, A]) = {
+    error: Error[T, P, E])(implicit targetMonoid: Monoid[T]): (Map[Int, T], Node[K, V, T, A]) = {
 
     def v(leaf: LeafNode[K, V, T, A]): T =
       validationData.getOrElse(leaf.index, targetMonoid.zero)
@@ -230,7 +231,7 @@ case class AnnotatedTree[K, V, T, A](root: Node[K, V, T, A]) {
     val errorOfSums = error.create(validationSum, targetPrediction) // Error of potential combined node.
 
     // Compare sum of errors and error of sums (and lower us out of the sum of errors Option).
-    val doCombine = errorOrdering.gteq(sumOfErrors, errorOfSums)
+    val doCombine = sumOfErrors >= errorOfSums
 
     if (doCombine) {
       // Create a new leaf from the combination of the children.

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Defaults.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Defaults.scala
@@ -1,6 +1,7 @@
 package com.stripe.brushfire
 
 import com.twitter.algebird._
+import spire.algebra.PartialOrder
 
 trait Defaults {
   import Predicate.{ Lt, IsEq }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Defaults.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Defaults.scala
@@ -1,7 +1,7 @@
 package com.stripe.brushfire
 
 import com.twitter.algebird._
-import spire.algebra.PartialOrder
+import spire.algebra.{ Order, PartialOrder }
 
 trait Defaults {
   import Predicate.{ Lt, IsEq }
@@ -14,7 +14,7 @@ trait Defaults {
   implicit def doubleSplitter[T: Monoid]: Splitter[Double, T] = BinnedSplitter(BinarySplitter[Double, T](Lt(_))) { d => downRez(d, 2, 100) }
   implicit def booleanSplitter[T: Group]: Splitter[Boolean, T] = BinarySplitter[Boolean, T](IsEq(_))
 
-  implicit def dispatchedSplitterWithSpaceSaver[A: Ordering, B, C: Ordering, D, L](
+  implicit def dispatchedSplitterWithSpaceSaver[A, B, C, D, L](
       implicit ordinal: Splitter[A, Map[L, Long]],
       nominal: Splitter[B, Map[L, Long]],
       continuous: Splitter[C, Map[L, Long]]): Splitter[Dispatched[A, B, C, D], Map[L, Long]] =

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
@@ -53,7 +53,7 @@ object Dispatched {
     sparseOrder: PartialOrder[D]
   ): PartialOrder[Dispatched[A, B, C, D]] =
     new PartialOrder[Dispatched[A, B, C, D]] {
-      def partialCompare(left: Dispatched[A, B, C, D], right: Dispatched[A, B, C, D]) =
+      def partialCompare(left: Dispatched[A, B, C, D], right: Dispatched[A, B, C, D]): Double =
         (left, right) match {
           case (Ordinal(l), Ordinal(r)) => ordinalOrder.partialCompare(l, r)
           case (Nominal(l), Nominal(r)) => nominalOrder.partialCompare(l, r)
@@ -63,10 +63,10 @@ object Dispatched {
         }
     }
 
-  def ordinal[A](a: A) = Ordinal(a)
-  def nominal[B](b: B) = Nominal(b)
-  def continuous[C](c: C) = Continuous(c)
-  def sparse[D](d: D) = Sparse(d)
+  def ordinal[A](a: A): Dispatched[A, Nothing, Nothing, Nothing] = Ordinal(a)
+  def nominal[B](b: B): Dispatched[Nothing, B, Nothing, Nothing] = Nominal(b)
+  def continuous[C](c: C): Dispatched[Nothing, Nothing, C, Nothing] = Continuous(c)
+  def sparse[D](d: D): Dispatched[Nothing, Nothing, Nothing, D] = Sparse(d)
 
   def wrapSplits[X, T, A, B, C, D](splits: Iterable[Split[X, T]])(fn: X => Dispatched[A, B, C, D]) =
     splits.map(_.map(fn))

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Dispatched.scala
@@ -1,7 +1,7 @@
 package com.stripe.brushfire
 
 import com.twitter.algebird._
-import spire.algebra.Order
+import spire.algebra.PartialOrder
 
 sealed trait Dispatched[+A, +B, +C, +D]
 
@@ -46,20 +46,21 @@ case class DispatchedSplitter[A, B, C, D, T](
 }
 
 object Dispatched {
-  implicit def dispatchedOrder[A, B, C, D](implicit
-    ordinalOrder: Order[A],
-    nominalOrder: Order[B],
-    continuousOrder: Order[C],
-    sparseOrder: Order[D]
-  ): Order[Dispatched[A, B, C, D]] =
-    new Order[Dispatched[A, B, C, D]] {
-      def compare(left: Dispatched[A, B, C, D], right: Dispatched[A, B, C, D]) = (left, right) match {
-        case (Ordinal(l), Ordinal(r)) => ordinalOrder.compare(l, r)
-        case (Nominal(l), Nominal(r)) => nominalOrder.compare(l, r)
-        case (Continuous(l), Continuous(r)) => continuousOrder.compare(l, r)
-        case (Sparse(l), Sparse(r)) => sparseOrder.compare(l, r)
-        case _ => sys.error("Values cannot be compared: " + (left, right))
-      }
+  implicit def dispatchedPartialOrder[A, B, C, D](implicit
+    ordinalOrder: PartialOrder[A],
+    nominalOrder: PartialOrder[B],
+    continuousOrder: PartialOrder[C],
+    sparseOrder: PartialOrder[D]
+  ): PartialOrder[Dispatched[A, B, C, D]] =
+    new PartialOrder[Dispatched[A, B, C, D]] {
+      def partialCompare(left: Dispatched[A, B, C, D], right: Dispatched[A, B, C, D]) =
+        (left, right) match {
+          case (Ordinal(l), Ordinal(r)) => ordinalOrder.partialCompare(l, r)
+          case (Nominal(l), Nominal(r)) => nominalOrder.partialCompare(l, r)
+          case (Continuous(l), Continuous(r)) => continuousOrder.partialCompare(l, r)
+          case (Sparse(l), Sparse(r)) => sparseOrder.partialCompare(l, r)
+          case _ => Double.NaN
+        }
     }
 
   def ordinal[A](a: A) = Ordinal(a)

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Injections.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Injections.scala
@@ -75,7 +75,7 @@ object JsonInjections {
     }
   }
 
-  implicit def predicateJsonInjection[V](implicit vInj: JsonNodeInjection[V], ord: Ordering[V] = null): JsonNodeInjection[Predicate[V]] = {
+  implicit def predicateJsonInjection[V](implicit vInj: JsonNodeInjection[V]): JsonNodeInjection[Predicate[V]] = {
     new AbstractJsonNodeInjection[Predicate[V]] {
       import Predicate._
 
@@ -120,9 +120,8 @@ object JsonInjections {
     // it). We do this by using `WithFallback`. If A is a unit, then we don't
     // need an injection. OTOH, if A isn't Unit, then we get an injection and
     // use that to serialize the annotation.
-    maybeAInj: (Unit =:= A) WithFallback JsonNodeInjection[A],
-    mon: Monoid[T],
-    ord: Ordering[V] = null): JsonNodeInjection[AnnotatedTree[K, V, T, A]] = {
+    maybeAInj: (Unit =:= A) WithFallback JsonNodeInjection[A]
+  ): JsonNodeInjection[AnnotatedTree[K, V, T, A]] = {
 
     implicit def nodeJsonNodeInjection: JsonNodeInjection[Node[K, V, T, A]] =
       new AbstractJsonNodeInjection[Node[K, V, T, A]] {

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Predicate.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Predicate.scala
@@ -1,5 +1,8 @@
 package com.stripe.brushfire
 
+import spire.algebra.PartialOrder
+import spire.implicits._
+
 /**
  * A `Predicate` is a function which accepts or rejects feature values.
  *
@@ -16,7 +19,7 @@ package com.stripe.brushfire
  *  - GtEq(c): x >= c
  *
  * Predicates can be negated using `!`, and can be transformed using
- * `map`. Evaluating a predicate requires an Ordering, but this
+ * `map`. Evaluating a predicate requires a PartialOrder[V], but this
  * constraint is not enforced during construction, only when `apply()`
  * is invoked.
  */
@@ -27,14 +30,14 @@ sealed abstract class Predicate[V] extends Product with Serializable {
   /**
    * Evaluate this predicate for the feature value `v`.
    */
-  def apply(v: V)(implicit ord: Ordering[V]): Boolean =
+  def apply(v: V)(implicit ord: PartialOrder[V]): Boolean =
     this match {
-      case IsEq(x) => ord.equiv(v, x)
-      case NotEq(x) => !ord.equiv(v, x)
-      case Lt(x) => ord.lt(v, x)
-      case LtEq(x) => ord.lteq(v, x)
-      case Gt(x) => ord.gt(v, x)
-      case GtEq(x) => ord.gteq(v, x)
+      case IsEq(x) => v === x
+      case NotEq(x) => v =!= x
+      case Lt(x) => v < x
+      case LtEq(x) => v <= x
+      case Gt(x) => v > x
+      case GtEq(x) => v >= x
     }
 
   /**
@@ -60,7 +63,7 @@ sealed abstract class Predicate[V] extends Product with Serializable {
    * Map the value types of this [[Predicate]] using `f`.
    *
    * Remember that in order to evaluate a Predicate[U] you will need
-   * to be able to provide a valid Ordering[U] instance.
+   * to be able to provide a valid PartialOrder[U] instance.
    */
   def map[U](f: V => U): Predicate[U] =
     this match {

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Reorder.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Reorder.scala
@@ -1,8 +1,9 @@
 package com.stripe.brushfire
 
-import scala.math.Ordering
 import scala.util.Random
 import scala.util.hashing.MurmurHash3
+import spire.algebra.Order
+import spire.syntax.all._
 
 /**
  * Simple data type that provides rules to order nodes during
@@ -66,7 +67,7 @@ object Reorder {
    * Reorder instance that traverses into the node with the higher
    * weight first.
    */
-  def weightedDepthFirst[A](implicit ev: Ordering[A]): Reorder[A] =
+  def weightedDepthFirst[A: Order]: Reorder[A] =
     new WeightedReorder()
 
   /**
@@ -94,11 +95,11 @@ object Reorder {
       g(n1, n2)
   }
 
-  class WeightedReorder[A](implicit ev: Ordering[A]) extends Reorder[A] {
+  class WeightedReorder[A: Order] extends Reorder[A] {
     def setSeed(seed: Option[String]): Reorder[A] =
       this
     def apply[N, S](n1: N, n2: N, f: N => A, g: (N, N) => S): S =
-      if (ev.compare(f(n1), f(n2)) >= 0) g(n1, n2) else g(n2, n1)
+      if (f(n1) >= f(n2)) g(n1, n2) else g(n2, n1)
   }
 
   class ShuffledReorder[A](r: Random) extends Reorder[A] {

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Splitters.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Splitters.scala
@@ -1,8 +1,9 @@
 package com.stripe.brushfire
 
 import com.twitter.algebird._
+import spire.algebra.PartialOrder
 
-case class BinarySplitter[V: Ordering, T: Monoid](partition: V => Predicate[V]) extends Splitter[V, T] {
+case class BinarySplitter[V: PartialOrder, T: Monoid](partition: V => Predicate[V]) extends Splitter[V, T] {
 
   type S = Map[V, T]
   def create(value: V, target: T) = Map(value -> target)

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Tree.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Tree.scala
@@ -2,6 +2,7 @@ package com.stripe.brushfire
 
 import com.stripe.bonsai.FullBinaryTreeOps
 import com.twitter.algebird._
+import spire.algebra.PartialOrder
 
 object Tree {
   def apply[K, V, T](node: Node[K, V, T, Unit]): Tree[K, V, T] =
@@ -10,7 +11,7 @@ object Tree {
   def singleton[K, V, T](t: T): Tree[K, V, T] =
     AnnotatedTree(LeafNode(0, t, ()))
 
-  def expand[K, V: Ordering, T: Monoid](times: Int, treeIndex: Int, leaf: LeafNode[K, V, T, Unit], splitter: Splitter[V, T], evaluator: Evaluator[V, T], stopper: Stopper[T], sampler: Sampler[K], instances: Iterable[Instance[K, V, T]]): Node[K, V, T, Unit] = {
+  def expand[K, V: PartialOrder, T: Monoid](times: Int, treeIndex: Int, leaf: LeafNode[K, V, T, Unit], splitter: Splitter[V, T], evaluator: Evaluator[V, T], stopper: Stopper[T], sampler: Sampler[K], instances: Iterable[Instance[K, V, T]]): Node[K, V, T, Unit] = {
     if (times > 0 && stopper.shouldSplit(leaf.target)) {
       implicit val jdSemigroup = splitter.semigroup
 

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
@@ -1,7 +1,7 @@
 package com.stripe.brushfire
 
 import com.stripe.bonsai.FullBinaryTreeOps
-import spire.algebra.PartialOrder
+import spire.algebra.{ Order, PartialOrder }
 
 /**
  * A `TreeTraversal` provides a way to find all of the leaves in a tree that
@@ -69,7 +69,7 @@ object TreeTraversal {
    * annotations. This means that if we have multiple valid candidate children,
    * we will traverse the child with the largest annotation first.
    */
-  def weightedDepthFirst[Tree, K, V: PartialOrder, T, A: Ordering](implicit treeOps: FullBinaryTreeOps[Tree, BranchLabel[K, V, A], LeafLabel[T, A]]): TreeTraversal[Tree, K, V, T, A] =
+  def weightedDepthFirst[Tree, K, V: PartialOrder, T, A: Order](implicit treeOps: FullBinaryTreeOps[Tree, BranchLabel[K, V, A], LeafLabel[T, A]]): TreeTraversal[Tree, K, V, T, A] =
     DepthFirstTreeTraversal[Tree, K, V, T, A](Reorder.weightedDepthFirst)
 
   /**

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
@@ -1,6 +1,7 @@
 package com.stripe.brushfire
 
 import com.stripe.bonsai.FullBinaryTreeOps
+import spire.algebra.PartialOrder
 
 /**
  * A `TreeTraversal` provides a way to find all of the leaves in a tree that
@@ -59,7 +60,7 @@ object TreeTraversal {
    * Performs a depth-first traversal of the tree, returning all matching leaf
    * nodes.
    */
-  implicit def depthFirst[Tree, K, V: Ordering, T, A](implicit treeOps: FullBinaryTreeOps[Tree, BranchLabel[K, V, A], LeafLabel[T, A]]): TreeTraversal[Tree, K, V, T, A] =
+  implicit def depthFirst[Tree, K, V: PartialOrder, T, A](implicit treeOps: FullBinaryTreeOps[Tree, BranchLabel[K, V, A], LeafLabel[T, A]]): TreeTraversal[Tree, K, V, T, A] =
     DepthFirstTreeTraversal(Reorder.unchanged)
 
   /**
@@ -68,8 +69,8 @@ object TreeTraversal {
    * annotations. This means that if we have multiple valid candidate children,
    * we will traverse the child with the largest annotation first.
    */
-  def weightedDepthFirst[Tree, K, V: Ordering, T, A: Ordering](implicit treeOps: FullBinaryTreeOps[Tree, BranchLabel[K, V, A], LeafLabel[T, A]]): TreeTraversal[Tree, K, V, T, A] =
-    DepthFirstTreeTraversal(Reorder.weightedDepthFirst)
+  def weightedDepthFirst[Tree, K, V: PartialOrder, T, A: Ordering](implicit treeOps: FullBinaryTreeOps[Tree, BranchLabel[K, V, A], LeafLabel[T, A]]): TreeTraversal[Tree, K, V, T, A] =
+    DepthFirstTreeTraversal[Tree, K, V, T, A](Reorder.weightedDepthFirst)
 
   /**
    * A depth first search for matching leaves, randomly choosing the order of
@@ -78,7 +79,7 @@ object TreeTraversal {
    * descend from that node are traversed before moving onto the node's
    * sibling.
    */
-  def randomDepthFirst[Tree, K, V: Ordering, T, A](seed: Option[Int] = None)(implicit treeOps: FullBinaryTreeOps[Tree, BranchLabel[K, V, A], LeafLabel[T, A]]): TreeTraversal[Tree, K, V, T, A] =
+  def randomDepthFirst[Tree, K, V: PartialOrder, T, A](seed: Option[Int] = None)(implicit treeOps: FullBinaryTreeOps[Tree, BranchLabel[K, V, A], LeafLabel[T, A]]): TreeTraversal[Tree, K, V, T, A] =
     DepthFirstTreeTraversal(Reorder.shuffled(seed.getOrElse(System.nanoTime.toInt)))
 
   /**
@@ -92,13 +93,13 @@ object TreeTraversal {
    * proportional to its probability of being sampled, relative to all the
    * other elements still in the set.
    */
-  def probabilisticWeightedDepthFirst[Tree, K, V: Ordering, T, A](seed: Option[Int] = None)(implicit treeOps: FullBinaryTreeOps[Tree, BranchLabel[K, V, A], LeafLabel[T, A]], conversion: A => Double): TreeTraversal[Tree, K, V, T, A] = {
+  def probabilisticWeightedDepthFirst[Tree, K, V: PartialOrder, T, A](seed: Option[Int] = None)(implicit treeOps: FullBinaryTreeOps[Tree, BranchLabel[K, V, A], LeafLabel[T, A]], conversion: A => Double): TreeTraversal[Tree, K, V, T, A] = {
     val n = seed.getOrElse(System.nanoTime.toInt)
     DepthFirstTreeTraversal(Reorder.probabilisticWeightedDepthFirst(n, conversion))
   }
 }
 
-case class DepthFirstTreeTraversal[Tree, K, V, T, A](reorder: Reorder[A])(implicit val treeOps: FullBinaryTreeOps[Tree, BranchLabel[K, V, A], LeafLabel[T, A]], ord: Ordering[V]) extends TreeTraversal[Tree, K, V, T, A] {
+case class DepthFirstTreeTraversal[Tree, K, V, T, A](reorder: Reorder[A])(implicit val treeOps: FullBinaryTreeOps[Tree, BranchLabel[K, V, A], LeafLabel[T, A]], ord: PartialOrder[V]) extends TreeTraversal[Tree, K, V, T, A] {
 
   import treeOps.{Node, foldNode}
 

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/Voters.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/Voters.scala
@@ -1,5 +1,7 @@
 package com.stripe.brushfire
 
+import spire.algebra.Order
+
 // Backwards compat.
 
 object SoftVoter {
@@ -7,7 +9,7 @@ object SoftVoter {
 }
 
 object ModeVoter {
-  def apply[L, M: Ordering]() = Voter.mode[L, M]
+  def apply[L, M: Order]() = Voter.mode[L, M]
 }
 
 object ThresholdVoter {

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
@@ -3,6 +3,7 @@ package com.stripe.brushfire.local
 import com.stripe.bonsai._
 import com.stripe.brushfire._
 import com.twitter.algebird._
+import spire.algebra.PartialOrder
 
 import AnnotatedTree.{AnnotatedTreeTraversal, fullBinaryTreeOpsForAnnotatedTree}
 

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
@@ -3,7 +3,7 @@ package com.stripe.brushfire.local
 import com.stripe.bonsai._
 import com.stripe.brushfire._
 import com.twitter.algebird._
-import spire.algebra.PartialOrder
+import spire.algebra.{ Order, PartialOrder }
 
 import AnnotatedTree.{AnnotatedTreeTraversal, fullBinaryTreeOpsForAnnotatedTree}
 
@@ -32,7 +32,7 @@ object Example extends Defaults {
       println(trainer.validate(BrierScoreError()))
     }
   
-    implicit val ord = Ordering.by[AveragedValue, Double] { _.value }
+    implicit val ord = Order.by[AveragedValue, Double] { _.value }
     trainer = trainer.prune(BrierScoreError())
     println(trainer.validate(AccuracyError()))
     println(trainer.validate(BrierScoreError()))

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Trainer.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Trainer.scala
@@ -3,10 +3,11 @@ package local
 
 import com.stripe.brushfire._
 import com.twitter.algebird._
+import spire.algebra.PartialOrder
 
 import AnnotatedTree.AnnotatedTreeTraversal
 
-case class Trainer[K: Ordering, V: Ordering, T: Monoid](
+case class Trainer[K: Ordering, V: PartialOrder, T: Monoid](
     trainingData: Iterable[Instance[K, V, T]],
     sampler: Sampler[K],
     trees: List[Tree[K, V, T]])(implicit traversal: AnnotatedTreeTraversal[K, V, T, Unit]) {
@@ -85,7 +86,7 @@ case class Trainer[K: Ordering, V: Ordering, T: Monoid](
 }
 
 object Trainer {
-  def apply[K: Ordering, V: Ordering, T: Monoid](trainingData: Iterable[Instance[K, V, T]], sampler: Sampler[K])(implicit traversal: AnnotatedTreeTraversal[K, V, T, Unit]): Trainer[K, V, T] = {
+  def apply[K: Ordering, V: PartialOrder, T: Monoid](trainingData: Iterable[Instance[K, V, T]], sampler: Sampler[K])(implicit traversal: AnnotatedTreeTraversal[K, V, T, Unit]): Trainer[K, V, T] = {
     val empty = 0.until(sampler.numTrees).toList.map { i => Tree.singleton[K, V, T](Monoid.zero) }
     Trainer(trainingData, sampler, empty)
   }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/package.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/package.scala
@@ -1,6 +1,8 @@
 package com.stripe
 
-package object brushfire {
+import spire.std.AnyInstances
+
+package object brushfire extends AnyInstances {
   type Tree[K, V, T] = AnnotatedTree[K, V, T, Unit]
   type BranchLabel[K, V, A] = (K, Predicate[V], A)
   type LeafLabel[T, A] = (Int, T, A)

--- a/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Trainer.scala
+++ b/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Trainer.scala
@@ -4,7 +4,7 @@ import com.stripe.brushfire._
 import com.twitter.scalding._
 import com.twitter.algebird._
 import com.twitter.bijection._
-import spire.algebra.PartialOrder
+import spire.algebra.{ Order, PartialOrder }
 import scala.util.Random
 
 abstract class TrainerJob(args: Args) extends ExecutionJob[Unit](args) with Defaults {
@@ -187,6 +187,7 @@ case class Trainer[K: Ordering, V: PartialOrder, T: Monoid](
    *
    */
   def prune[P, E](path: String, error: Error[T, P, E])(implicit voter: Voter[T, P], inj: Injection[Tree[K, V, T], String], ord: Ordering[E]): Trainer[K, V, T] = {
+    implicit val order: Order[E] = Order.from(ord.compare)
     flatMapTrees {
       case (trainingData, sampler, trees) =>
         lazy val treeMap = trees.toMap

--- a/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Trainer.scala
+++ b/brushfire-scalding/src/main/scala/com/stripe/brushfire/scalding/Trainer.scala
@@ -4,7 +4,7 @@ import com.stripe.brushfire._
 import com.twitter.scalding._
 import com.twitter.algebird._
 import com.twitter.bijection._
-
+import spire.algebra.PartialOrder
 import scala.util.Random
 
 abstract class TrainerJob(args: Args) extends ExecutionJob[Unit](args) with Defaults {
@@ -21,7 +21,7 @@ object TreeSource {
   }
 }
 
-case class Trainer[K: Ordering, V: Ordering, T: Monoid](
+case class Trainer[K: Ordering, V: PartialOrder, T: Monoid](
     @transient trainingDataExecution: Execution[TypedPipe[Instance[K, V, T]]],
     @transient samplerExecution: Execution[Sampler[K]],
     @transient treeExecution: Execution[TypedPipe[(Int, Tree[K, V, T])]],
@@ -335,7 +335,7 @@ case class Trainer[K: Ordering, V: Ordering, T: Monoid](
 object Trainer {
   val MaxReducers = 20
 
-  def apply[K: Ordering, V: Ordering, T: Monoid](trainingData: TypedPipe[Instance[K, V, T]], sampler: Sampler[K]): Trainer[K, V, T] = {
+  def apply[K: Ordering, V: PartialOrder, T: Monoid](trainingData: TypedPipe[Instance[K, V, T]], sampler: Sampler[K]): Trainer[K, V, T] = {
     val empty = 0.until(sampler.numTrees).map { treeIndex => (treeIndex, Tree.singleton[K, V, T](Monoid.zero)) }
     Trainer(
       Execution.from(trainingData),

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -11,6 +11,7 @@ object Deps {
     val bijection = "0.7.0"
     val bonsai = "0.1.3"
     val tDigest = "3.1"
+    val spire = "0.11.0"
 
     val hadoopClient = "2.5.2"
     val scalding = "0.13.1"
@@ -30,6 +31,7 @@ object Deps {
   val jacksonXC      = "org.codehaus.jackson" % "jackson-xc"         % V.jackson
   val jacksonJAXRS   = "org.codehaus.jackson" % "jackson-jaxrs"      % V.jackson
   val tDigest        = "com.tdunning"         % "t-digest"           % V.tDigest
+  val spire          = "org.spire-math"      %% "spire"              % V.spire
 
   val hadoopClient   = "org.apache.hadoop"    % "hadoop-client"      % V.hadoopClient   % "provided"
   val scaldingCore   = "com.twitter"         %% "scalding-core"      % V.scalding


### PR DESCRIPTION
This PR moves brushfire-core over to use `spire.algebra.PartialOrder` and `spire.algebra.Order` where applicable. At this point we don't actually _use_ any partial orderings, but the support is there.

Before we merge this I'd like to add some tests to prove this is working, and maybe flesh out support for the _is present_ use-case a bit. What do you all think we need?

Review by @tixxit and @avibryant.
