### PR TITLE
Erik non lazy initialization

### DIFF
--- a/brushfire-core/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
@@ -118,10 +118,15 @@ case class DepthFirstTreeTraversal[Tree, K, V, T, A](reorder: Reorder[A])(implic
     val leafF: LeafLabel[T, A] => Stream[LeafLabel[T, A]] =
       _ #:: Stream.empty
 
+    // determine the order to traverse into two given nodes. this var
+    // is initialized just after 'recurse' -- it is basically a lazy
+    // val but with better performance.
     var reorderF: (Node, Node) => Stream[LeafLabel[T, A]] = null
 
     // recurse into branch nodes, going left, right, or both,
-    // depending on what our predicate says.
+    // depending on what our predicate says. this var is initialized
+    // just after 'recurse' -- it is basically a lazy val but with
+    // better performance.
     var branchF: (Node, Node, BranchLabel[K, V, A]) => Stream[LeafLabel[T, A]] = null
 
     // recursively handle each node. the foldNode method decides
@@ -129,8 +134,10 @@ case class DepthFirstTreeTraversal[Tree, K, V, T, A](reorder: Reorder[A])(implic
     def recurse(node: Node): Stream[LeafLabel[T, A]] =
       foldNode(node)(branchF, leafF)
 
+    // now that recurse is defined we can initialize this
     reorderF = (n1, n2) => recurse(n1) #::: recurse(n2)
 
+    // now that recurse is defined we can initialize this
     branchF = (lc, rc, t) => t match {
       case (k, p, _) => row.get(k) match {
         case Some(v) => if (p(v)) recurse(lc) else recurse(rc)
@@ -138,7 +145,12 @@ case class DepthFirstTreeTraversal[Tree, K, V, T, A](reorder: Reorder[A])(implic
       }
     }
 
-    // do it!
+    // ok, now do it!
+    //
+    // the reason we did all the work above of defining the functions
+    // in variables is that this makes our traversal more
+    // efficient. otherwise we'd have to generate Function1 instances
+    // at each level of each tree.
     recurse(start)
   }
 }


### PR DESCRIPTION
This is a small change that improves the efficiency of our traversals.

@jvns noticed that accessing the `lazy val` function instances was slowing down our traversals. In this case (since they are local variables only used by one thread) we can replace the `lazy val` variables with `var` variables which we initialize as soon as it is legal (we can't use `val` due to an overly-cautious circularity check done by scalac).

The tests pass and @jvns has verified that this branch seems to improve the performance of the traversals.

?r @tixxit @jvns @avibryant 