### PR TITLE
Bounded-memory local training

### DIFF
--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
@@ -31,10 +31,5 @@ object Example extends Defaults {
       println(trainer.validate(AccuracyError()))
       println(trainer.validate(BrierScoreError()))
     }
-
-    implicit val ord = Ordering.by[AveragedValue, Double] { _.value }
-    trainer = trainer.prune(BrierScoreError())
-    println(trainer.validate(AccuracyError()))
-    println(trainer.validate(BrierScoreError()))
   }
 }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
@@ -9,28 +9,29 @@ import AnnotatedTree.{AnnotatedTreeTraversal, fullBinaryTreeOpsForAnnotatedTree}
 object Example extends Defaults {
 
   def main(args: Array[String]) {
-    val cols = args.toList
-  
-    val trainingData = io.Source.stdin.getLines.map { line =>
+    val path = args.head
+    val cols = args.tail.toList
+
+    val trainingData = Lines(path).map { line =>
       val parts = line.split(",").reverse.toList
       val label = parts.head
       val values = parts.tail.map { s => s.toDouble }
       Instance(line, 0L, Map(cols.zip(values): _*), Map(label -> 1L))
-    }.toList
-  
+    }.toIterable
+
     var trainer =
       Trainer(trainingData, KFoldSampler(4))
         .updateTargets
-  
+
     println(trainer.validate(AccuracyError()))
     println(trainer.validate(BrierScoreError()))
-  
+
     1.to(10).foreach { i =>
       trainer = trainer.expand(1)
       println(trainer.validate(AccuracyError()))
       println(trainer.validate(BrierScoreError()))
     }
-  
+
     implicit val ord = Ordering.by[AveragedValue, Double] { _.value }
     trainer = trainer.prune(BrierScoreError())
     println(trainer.validate(AccuracyError()))

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
@@ -24,12 +24,10 @@ object Example extends Defaults {
         .updateTargets
 
     println(trainer.validate(AccuracyError()))
-    println(trainer.validate(BrierScoreError()))
 
     1.to(10).foreach { i =>
-      trainer = trainer.expand(1)
+      trainer = trainer.expand(5)
       println(trainer.validate(AccuracyError()))
-      println(trainer.validate(BrierScoreError()))
     }
   }
 }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Example.scala
@@ -26,7 +26,7 @@ object Example extends Defaults {
     println(trainer.validate(AccuracyError()))
 
     1.to(10).foreach { i =>
-      trainer = trainer.expand(5)
+      trainer = trainer.expand(1)
       println(trainer.validate(AccuracyError()))
     }
   }

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Lines.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Lines.scala
@@ -1,0 +1,63 @@
+package com.stripe.brushfire.local
+
+import java.io._
+import scala.collection.generic.CanBuildFrom
+
+abstract class Lines[A](val file: File, val charset: String = "UTF-8") { self =>
+
+  def iterator: Iterator[A]
+
+  def toIterable: Iterable[A] =
+    new IterableLines(this)
+
+  def filter(f: A => Boolean): Lines[A] =
+    new Lines[A](file) {
+      def iterator: Iterator[A] = self.iterator.filter(f)
+    }
+
+  def map[B](f: A => B): Lines[B] =
+    new Lines[B](file) {
+      def iterator: Iterator[B] = self.iterator.map(f)
+    }
+
+  def flatMap[B](f: A => Iterable[B]): Lines[B] =
+    new Lines[B](file) {
+      def iterator: Iterator[B] = self.iterator.flatMap(a => f(a).iterator)
+    }
+
+  def foldLeft[B](b0: B)(f: (B, A) => B): B =
+    iterator.foldLeft(b0)(f)
+
+  def foreach(f: A => Unit): Unit =
+    iterator.foreach(f)
+
+  override def toString(): String =
+    s"Lines(<over $file with $charset>)"
+}
+
+object Lines {
+  def apply(f: File, cs: String = "UTF-8"): Lines[String] =
+    new Lines[String](f, cs) {
+      def iterator: Iterator[String] =
+        new Iterator[String] {
+          println("Opening " + f)
+          val reader = new BufferedReader(new InputStreamReader(new FileInputStream(file), charset))
+          var line: String = reader.readLine()
+          if (line == null) reader.close()
+          def hasNext(): Boolean = line != null
+          def next(): String = {
+            if (line == null) throw new NoSuchElementException("next on empty iterator")
+            val out = line
+            line = reader.readLine()
+            if (line == null) reader.close()
+            out
+          }
+        }
+    }
+
+  def apply(pathname: String): Lines[String] = apply(new File(pathname))
+}
+
+class IterableLines[A](lines: Lines[A]) extends Iterable[A] {
+  def iterator: Iterator[A] = lines.iterator
+}

--- a/brushfire-core/src/main/scala/com/stripe/brushfire/local/Trainer.scala
+++ b/brushfire-core/src/main/scala/com/stripe/brushfire/local/Trainer.scala
@@ -56,7 +56,7 @@ case class Trainer[K: Ordering, V: Ordering, T: Monoid](
     }
 
     val newTrees = 0.until(trees.size).toList.map{i => newTreeMap(i)}
-    Trainer(trainingData, sampler, trees)
+    Trainer(trainingData, sampler, newTrees)
   }
 
   def updateTargets: Trainer[K, V, T] = {

--- a/example/iris-local
+++ b/example/iris-local
@@ -1,5 +1,5 @@
 #!/bin/sh
-java -Xmx2G -cp ../brushfire-scalding/target/target/brushfire-scalding-0.6.0-SNAPSHOT-jar-with-dependencies.jar \
+java -Xmx2G -cp ../brushfire-scalding/target/scala-2.10/brushfire-scalding-0.7.1-SNAPSHOT-jar-with-dependencies.jar \
 com.stripe.brushfire.local.Example \
-petal-width petal-length sepal-width sepal-length \
-< iris.data
+iris.data \
+petal-width petal-length sepal-width sepal-length


### PR DESCRIPTION
Some work from the plane, ?r @striation @tixxit 

This has the same goal as #77 but is deliberately worse code (for now) in the interests of being less invasive and getting merged quickly. It completely avoids making any useful abstractions and instead just provides the most direct implementation of a single-node, single-pass-per-expansion local trainer.

The only interesting thing it does is this: by streaming over the training data we avoid using O(training set) memory, but if we try to expand an entire level at once, we still have an O(2^depth * features) problem. So `expand` takes a parameter of the maximum number of tree leaves to try to expand, per tree, in any one pass, and randomly picks which ones to do (using something like reservoir sampling to get a uniform sample of leaves that don't meet the stopping criteria). This lets you trade off memory use vs. performance (by forcing more passes but capping the memory).

There's still the need to keep all of the trees in memory at once, so it's not *truly* constant memory, but that's harder to avoid. If it becomes a problem we can look at using bonsai representations even during training...