### PR TITLE
Experimental iterator for depth-first tree traversals

### DIFF
--- a/brushfire-tree/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
+++ b/brushfire-tree/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
@@ -126,6 +126,17 @@ case class DepthFirstTreeTraversal[Tree, K, V, T, A](reorder: Reorder[A])(implic
         Stream.empty[Node]
       }
     }
+    final def asIterator: Iterator[Node] = {
+      var adv = this
+      new Iterator[Node] {
+        def next: Node = {
+          val (node, nextAdv) = adv.next
+          adv = nextAdv
+          node
+        }
+        def hasNext: Boolean = adv.hasNext
+      }
+    }
 
     private val getAnnotation: Node => A =
       node => treeOps.foldNode(node)((_, _, bl) => bl._3, ll => ll._3)


### PR DESCRIPTION
I don't intend to merge this pull request. I'm putting this up here to demonstrate a method for obtaining a functional iterator for trees. This was a way for me to get a bit more familiar with dependent types (since we need to work with the type member of `FullBinaryTreeOps`) and generally play with Scala data structures.

At its cores, this PR introduces a wrapper around a stack of tree nodes, which allows us to iterate through the tree's nodes depth-first.

cc @rob-stripe  @sritchie-stripe @thomas-stripe @erik-stripe @oscar-stripe @kelley-stripe @avi-stripe 