### PR TITLE
Add Scala 2.12 support

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,15 +2,19 @@ organization in ThisBuild := "com.stripe"
 
 scalaVersion in ThisBuild := "2.11.5"
 
-crossScalaVersions in ThisBuild := Seq("2.10.4", "2.11.5")
+crossScalaVersions in ThisBuild := Seq("2.10.4", "2.11.5", "2.12.1")
 
 scalacOptions in ThisBuild ++= Seq(
-  "-Yinline-warnings",
   "-deprecation",
   "-feature",
   "-unchecked",
   "-optimize"
 )
+
+scalacOptions in ThisBuild ++= (scalaBinaryVersion.value match {
+  case "2.12" => Seq.empty
+  case "2.10" | "2.11" => Seq("-Yinline-warnings")
+})
 
 autoAPIMappings in ThisBuild := true
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -6,20 +6,20 @@ object Resolvers {
 
 object Deps {
   object V {
-    val algebird = "0.12.2"
+    val algebird = "0.13.0"
     val jackson = "1.9.13"
-    val bijection = "0.7.0"
     val bonsai = "0.2.1"
+    val bijection = "0.9.5"
     val tDigest = "3.1"
 
     val hadoopClient = "2.5.2"
     val scalding = "0.16.1-RC3"
-    val chill = "0.5.2"
+    val chill = "0.9.2"
 
     val finatra = "1.6.0"
 
-    val scalaTest = "2.2.4"
-    val scalaCheck = "1.12.2"
+    val scalaTest = "3.0.1"
+    val scalaCheck = "1.13.4"
   }
 
   val algebirdCore   = "com.twitter"         %% "algebird-core"      % V.algebird

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -14,7 +14,7 @@ object Deps {
 
     val hadoopClient = "2.5.2"
     val scalding = "0.16.1-RC3"
-    val chill = "0.9.2"
+    val chill = "0.7.7"
 
     val finatra = "1.6.0"
 


### PR DESCRIPTION
Upgrde dependencies to versions that support Scala 2.12. I left two
deps intact:

  * scalding
  * brushfire

because they don't have Scala 2.12 releases yet.
I tested this chnage with locally build SNAPSHOTs of scalding-core and
brushfire and all tests passed on Scala 2.12.