### PR TITLE
Update bonsai to 0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,9 @@
 language: scala
 scala:
-  - 2.11.5
-  - 2.10.5
+  - 2.11.11
+  - 2.10.6
 jdk:
+  - oraclejdk8
   - oraclejdk7
   - openjdk7
 sudo: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,9 @@
 language: scala
 scala:
-  - 2.11.11
-  - 2.10.6
+  - 2.11.12
+  - 2.12.6
 jdk:
   - oraclejdk8
-  - oraclejdk7
-  - openjdk7
 sudo: false
 script:
   - sbt ++$TRAVIS_SCALA_VERSION test

--- a/brushfire-tree/src/main/scala/com/stripe/brushfire/AnnotatedTree.scala
+++ b/brushfire-tree/src/main/scala/com/stripe/brushfire/AnnotatedTree.scala
@@ -19,9 +19,9 @@ sealed abstract class Node[K, V, T, A] {
         (nextId + 1, LeafNode(nextId, target, annotation))
     }
 
-  def fold[B](f: (Node[K, V, T, A], Node[K, V, T, A], (K, Predicate[V], A)) => B, g: Tuple3[Int, T, A] => B): B =
+  def fold[B](f: ((K, Predicate[V], A), Node[K, V, T, A], Node[K, V, T, A]) => B, g: Tuple3[Int, T, A] => B): B =
     this match {
-      case SplitNode(k, p, lc, rc, a) => f(lc, rc, (k, p, a))
+      case SplitNode(k, p, lc, rc, a) => f((k, p, a), lc, rc)
       case LeafNode(index, target, a) => g((index, target, a))
     }
 }
@@ -326,6 +326,6 @@ class FullBinaryTreeOpsForAnnotatedTree[K, V, T, A] extends FullBinaryTreeOps[An
   def root(t: AnnotatedTree[K, V, T, A]): Option[Node] = Some(t.root)
 
   def foldNode[B](node: Node)(
-    f: (Node, Node, (K, Predicate[V], A)) => B,
+    f: ((K, Predicate[V], A), Node, Node) => B,
     g: Tuple3[Int, T, A] => B): B = node.fold(f, g)
 }

--- a/brushfire-tree/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
+++ b/brushfire-tree/src/main/scala/com/stripe/brushfire/TreeTraversal.scala
@@ -112,7 +112,7 @@ case class DepthFirstTreeTraversal[Tree, K, V, T, A](reorder: Reorder[A])(implic
 
     // pull the A value out of a branch or leaf.
     val getAnnotation: Node => A =
-      node => foldNode(node)((_, _, bl) => bl._3, ll => ll._3)
+      node => foldNode(node)((bl, _, _) => bl._3, ll => ll._3)
 
     // construct a singleton stream from a leaf
     val leafF: LeafLabel[T, A] => Stream[LeafLabel[T, A]] =
@@ -127,7 +127,7 @@ case class DepthFirstTreeTraversal[Tree, K, V, T, A](reorder: Reorder[A])(implic
     // depending on what our predicate says. this var is initialized
     // just after 'recurse' -- it is basically a lazy val but with
     // better performance.
-    var branchF: (Node, Node, BranchLabel[K, V, A]) => Stream[LeafLabel[T, A]] = null
+    var branchF: (BranchLabel[K, V, A], Node, Node) => Stream[LeafLabel[T, A]] = null
 
     // recursively handle each node. the foldNode method decides
     // whether to handle it as a branch or a leaf.
@@ -138,7 +138,7 @@ case class DepthFirstTreeTraversal[Tree, K, V, T, A](reorder: Reorder[A])(implic
     reorderF = (n1, n2) => recurse(n1) #::: recurse(n2)
 
     // now that recurse is defined we can initialize this
-    branchF = (lc, rc, t) => t match {
+    branchF = (t, lc, rc) => t match {
       case (k, p, _) => row.get(k) match {
         case Some(v) => if (p(v)) recurse(lc) else recurse(rc)
         case None => r(lc, rc, getAnnotation, reorderF)

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 organization in ThisBuild := "com.stripe"
 
-scalaVersion in ThisBuild := "2.11.11"
+scalaVersion in ThisBuild := "2.11.12"
 
-crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.11", "2.12.2")
+crossScalaVersions in ThisBuild := Seq("2.11.12", "2.12.6")
 
 scalacOptions in ThisBuild ++= Seq(
   "-deprecation",
@@ -13,7 +13,7 @@ scalacOptions in ThisBuild ++= Seq(
 
 scalacOptions in ThisBuild ++= (scalaBinaryVersion.value match {
   case "2.12" => Seq.empty
-  case "2.10" | "2.11" => Seq("-Yinline-warnings")
+  case "2.11" => Seq("-Yinline-warnings")
 })
 
 autoAPIMappings in ThisBuild := true

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 organization in ThisBuild := "com.stripe"
 
-scalaVersion in ThisBuild := "2.11.5"
+scalaVersion in ThisBuild := "2.11.11"
 
-crossScalaVersions in ThisBuild := Seq("2.10.4", "2.11.5", "2.12.1")
+crossScalaVersions in ThisBuild := Seq("2.10.6", "2.11.11", "2.12.2")
 
 scalacOptions in ThisBuild ++= Seq(
   "-deprecation",

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -8,7 +8,7 @@ object Deps {
   object V {
     val algebird = "0.13.0"
     val jackson = "1.9.13"
-    val bonsai = "0.2.1"
+    val bonsai = "0.3.0"
     val bijection = "0.9.5"
     val tDigest = "3.1"
 

--- a/project/Deps.scala
+++ b/project/Deps.scala
@@ -13,7 +13,7 @@ object Deps {
     val tDigest = "3.1"
 
     val hadoopClient = "2.5.2"
-    val scalding = "0.16.1-RC3"
+    val scalding = "0.17.4"
     val chill = "0.7.7"
 
     val finatra = "1.6.0"


### PR DESCRIPTION
Updates to [the new bonsai release](https://github.com/stripe/bonsai/releases/tag/v0.3.0) and bumps the Scala version numbers.